### PR TITLE
feat: dpi awareness

### DIFF
--- a/LarsWM.Bar/BarManagerService.cs
+++ b/LarsWM.Bar/BarManagerService.cs
@@ -4,6 +4,7 @@ using LarsWM.Infrastructure.Bussing;
 using System.Reactive.Linq;
 using System;
 using System.Threading;
+using LarsWM.Domain.UserConfigs;
 
 namespace LarsWM.Bar
 {
@@ -11,11 +12,13 @@ namespace LarsWM.Bar
   {
     private Bus _bus;
     private WorkspaceService _workspaceService;
+    private UserConfigService _userConfigService;
 
-    public BarManagerService(Bus bus, WorkspaceService workspaceService)
+    public BarManagerService(Bus bus, WorkspaceService workspaceService, UserConfigService userConfigService)
     {
       _bus = bus;
       _workspaceService = workspaceService;
+      _userConfigService = userConfigService;
     }
 
     public void Init()
@@ -30,7 +33,7 @@ namespace LarsWM.Bar
           {
             application.Dispatcher.Invoke(() =>
             {
-              var bar = new MainWindow((@event as MonitorAddedEvent).AddedMonitor, _workspaceService, _bus);
+              var bar = new MainWindow((@event as MonitorAddedEvent).AddedMonitor, _workspaceService, _bus, _userConfigService);
               bar.Show();
             });
           });

--- a/LarsWM.Bar/MainWindow.xaml
+++ b/LarsWM.Bar/MainWindow.xaml
@@ -10,8 +10,6 @@
   ResizeMode="NoResize"
   Background="#101010"
   Title="LarsWMBar"
-  Height="auto"
-  Width="1200"
   ShowInTaskbar="False"
   Topmost="True">
   <Grid>
@@ -22,7 +20,7 @@
     </Grid.ColumnDefinitions>
     <Grid.RowDefinitions>
       <RowDefinition Height="10" />
-      <RowDefinition Height="auto" />
+      <RowDefinition Height="*" />
       <RowDefinition Height="10" />
     </Grid.RowDefinitions>
 
@@ -49,9 +47,8 @@
             Foreground="White"
             BorderBrush="Transparent"
             BorderThickness="0"
-            Width="35"
-            Height="35"
-            HorizontalAlignment="Left" />
+            MinWidth="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"
+            MinHeight="{Binding ActualWidth, RelativeSource={RelativeSource Self}}" />
 
           <DataTemplate.Triggers>
             <DataTrigger

--- a/LarsWM.Bar/MainWindow.xaml
+++ b/LarsWM.Bar/MainWindow.xaml
@@ -11,6 +11,8 @@
   Background="#101010"
   Title="LarsWMBar"
   ShowInTaskbar="False"
+  Width="800"
+  Height="50"
   Topmost="True">
   <Grid>
     <Grid.ColumnDefinitions>

--- a/LarsWM.Bar/MainWindow.xaml.cs
+++ b/LarsWM.Bar/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 using LarsWM.Domain.Containers.Events;
+using LarsWM.Domain.UserConfigs;
 
 namespace LarsWM.Bar
 {
@@ -19,22 +20,25 @@ namespace LarsWM.Bar
   {
     private Bus _bus { get; }
     private WorkspaceService _workspaceService { get; }
-    private static object _lock = new object();
+    private UserConfigService _userConfigService { get; }
     private ObservableCollection<Workspace> _workspaces = new ObservableCollection<Workspace>();
 
-    public MainWindow(Monitor monitor, WorkspaceService workspaceService, Bus bus)
+    public MainWindow(Monitor monitor, WorkspaceService workspaceService, Bus bus, UserConfigService userConfigService)
     {
       _bus = bus;
       _workspaceService = workspaceService;
+      _userConfigService = userConfigService;
 
       InitializeComponent();
 
       // TODO: Bind padding, bg color, button bg color and font from user config.
       Top = monitor.Y;
       Left = monitor.X;
-      Width = monitor.Width;
-      // TODO: Change height to be set in XAML.
-      Height = 50;
+      Height = _userConfigService.UserConfig.Bar.Height;
+
+      // WPF automatically changes the size of the bar based on display scale factor. This causes
+      // the bar width to overflow on scale factors > 100%, so need to adjust accordingly.
+      Width = Convert.ToInt32(monitor.Width / monitor.ScaleFactor);
 
       RefreshState(monitor);
 

--- a/LarsWM.Bar/MainWindow.xaml.cs
+++ b/LarsWM.Bar/MainWindow.xaml.cs
@@ -10,6 +10,8 @@ using System.Windows;
 using System.Windows.Controls;
 using LarsWM.Domain.Containers.Events;
 using LarsWM.Domain.UserConfigs;
+using System.Windows.Interop;
+using static LarsWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace LarsWM.Bar
 {
@@ -18,6 +20,7 @@ namespace LarsWM.Bar
   /// </summary>
   public partial class MainWindow : Window
   {
+    private Monitor _monitor { get; }
     private Bus _bus { get; }
     private WorkspaceService _workspaceService { get; }
     private UserConfigService _userConfigService { get; }
@@ -25,23 +28,15 @@ namespace LarsWM.Bar
 
     public MainWindow(Monitor monitor, WorkspaceService workspaceService, Bus bus, UserConfigService userConfigService)
     {
+      _monitor = monitor;
       _bus = bus;
       _workspaceService = workspaceService;
       _userConfigService = userConfigService;
 
       InitializeComponent();
-
-      // TODO: Bind padding, bg color, button bg color and font from user config.
-      Top = monitor.Y;
-      Left = monitor.X;
-      Height = _userConfigService.UserConfig.Bar.Height;
-
-      // WPF automatically changes the size of the bar based on display scale factor. This causes
-      // the bar width to overflow on scale factors > 100%, so need to adjust accordingly.
-      Width = Convert.ToInt32(monitor.Width / monitor.ScaleFactor);
+      SourceInitialized += MainWindow_SourceInitialized;
 
       RefreshState(monitor);
-
       WorkspaceItems.ItemsSource = _workspaces;
 
       var workspaceAttachedEvent = _bus.Events.Where(@event => @event is WorkspaceAttachedEvent);
@@ -59,6 +54,29 @@ namespace LarsWM.Bar
 
       foreach (var workspace in monitor.Children)
         _workspaces.Add(workspace as Workspace);
+    }
+
+    private void MainWindow_SourceInitialized(object sender, EventArgs e)
+    {
+      PositionWindow();
+    }
+
+    /// <summary>
+    /// Position and size the WPF window manually using WinAPI. When using `PerMonitorAwareV2` DPI
+    /// awareness, positioning the window with WPF bindings is ambiguous and annoying.
+    /// Ref: https://github.com/dotnet/wpf/issues/4127#issuecomment-790194817
+    /// </summary>
+    public void PositionWindow()
+    {
+      var windowHandle = new WindowInteropHelper(this).Handle;
+
+      // Since window size is set manually, need to scale up height to make window DPI responsive.
+      var scaledHeight = Convert.ToInt32(_userConfigService.UserConfig.Bar.Height * _monitor.ScaleFactor);
+
+      // The first move puts it on the correct monitor, which triggers WM_DPICHANGED.
+      // The +1/-1 coerces WPF to update Top/Left/Width/Height in the second move.
+      MoveWindow(windowHandle, _monitor.X + 1, _monitor.Y, _monitor.Width - 1, scaledHeight, false);
+      MoveWindow(windowHandle, _monitor.X, _monitor.Y, _monitor.Width, scaledHeight, true);
     }
 
     private void OnWorkspaceButtonClick(object sender, RoutedEventArgs e)

--- a/LarsWM.Bootstrapper/Program.cs
+++ b/LarsWM.Bootstrapper/Program.cs
@@ -4,6 +4,7 @@ using LarsWM.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Diagnostics;
+using static LarsWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace LarsWM.Bootstrapper
 {
@@ -16,6 +17,9 @@ namespace LarsWM.Bootstrapper
     static void Main()
     {
       Debug.WriteLine("Application started");
+
+      // Set the process-default DPI awareness.
+      SetProcessDpiAwarenessContext(DpiAwarenessContext.Context_PerMonitorAwareV2);
 
       var serviceCollection = new ServiceCollection();
       serviceCollection.AddInfrastructureServices();

--- a/LarsWM.Domain/Monitors/Monitor.cs
+++ b/LarsWM.Domain/Monitors/Monitor.cs
@@ -1,7 +1,8 @@
 ﻿using LarsWM.Domain.Containers;
 using LarsWM.Domain.Workspaces;
+using LarsWM.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace LarsWM.Domain.Monitors
@@ -18,6 +19,10 @@ namespace LarsWM.Domain.Monitors
     public Workspace DisplayedWorkspace;  // Alternatively add IsDisplayed/IsVisible property to Workspace instance
 
     public Screen Screen { get; }
+
+    private MonitorService _monitorService = ServiceLocator.Provider.GetRequiredService<MonitorService>();
+
+    public uint Dpi => _monitorService.GetMonitorDpi(Screen);
 
     public Monitor(Screen screen)
     {

--- a/LarsWM.Domain/Monitors/Monitor.cs
+++ b/LarsWM.Domain/Monitors/Monitor.cs
@@ -24,6 +24,8 @@ namespace LarsWM.Domain.Monitors
 
     public uint Dpi => _monitorService.GetMonitorDpi(Screen);
 
+    public decimal ScaleFactor => decimal.Divide(Dpi, 96);
+
     public Monitor(Screen screen)
     {
       Screen = screen;

--- a/LarsWM.Domain/Monitors/MonitorService.cs
+++ b/LarsWM.Domain/Monitors/MonitorService.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using LarsWM.Domain.Common.Enums;
 using LarsWM.Domain.Containers;
 using LarsWM.Domain.Windows;
+using static LarsWM.Infrastructure.WindowsApi.WindowsApiService;
 
 namespace LarsWM.Domain.Monitors
 {
@@ -48,6 +49,18 @@ namespace LarsWM.Domain.Monitors
     {
       var focusedContainer = _containerService.FocusedContainer;
       return GetMonitorFromChildContainer(focusedContainer);
+    }
+
+    public uint GetMonitorDpi(Screen screen)
+    {
+      // Get a handle to the monitor from a `Screen`.
+      var point = new System.Drawing.Point(screen.Bounds.Left + 1, screen.Bounds.Top + 1);
+      var monitorHandle = MonitorFromPoint(point, MonitorFromPointFlags.MONITOR_DEFAULTTONEAREST);
+
+      uint dpiX, dpiY;
+      GetDpiForMonitor(monitorHandle, DpiType.Effective, out dpiX, out dpiY);
+
+      return dpiX;
     }
 
     /// <summary>

--- a/LarsWM.Domain/Windows/Window.cs
+++ b/LarsWM.Domain/Windows/Window.cs
@@ -37,7 +37,11 @@ namespace LarsWM.Domain.Windows
     public WindowRect Location => _windowService.GetLocationOfHandle(Hwnd);
 
     public bool CanLayout => !_windowService.IsHandleCloaked(Hwnd)
-        && _windowService.IsHandleManageable(Hwnd);
+      && _windowService.IsHandleManageable(Hwnd);
+
+    public WS WindowStyles => _windowService.GetWindowStyles(Hwnd);
+
+    public WS_EX WindowStylesEx => _windowService.GetWindowStylesEx(Hwnd);
 
     public bool HasWindowStyle(WS style)
     {

--- a/LarsWM.Domain/Windows/Window.cs
+++ b/LarsWM.Domain/Windows/Window.cs
@@ -39,6 +39,8 @@ namespace LarsWM.Domain.Windows
     public bool CanLayout => !_windowService.IsHandleCloaked(Hwnd)
       && _windowService.IsHandleManageable(Hwnd);
 
+    public uint Dpi => GetDpiForWindow(Hwnd);
+
     public WS WindowStyles => _windowService.GetWindowStyles(Hwnd);
 
     public WS_EX WindowStylesEx => _windowService.GetWindowStylesEx(Hwnd);

--- a/LarsWM.Domain/Windows/WindowService.cs
+++ b/LarsWM.Domain/Windows/WindowService.cs
@@ -79,18 +79,24 @@ namespace LarsWM.Domain.Windows
       return rect;
     }
 
+    public WS_EX GetWindowStylesEx(IntPtr handle)
+    {
+      return unchecked((WS_EX)GetWindowLongPtr(handle, (int)(GWL_EXSTYLE)).ToInt64());
+    }
+
+    public WS GetWindowStyles(IntPtr handle)
+    {
+      return unchecked((WS)GetWindowLongPtr(handle, (int)(GWL_STYLE)).ToInt64());
+    }
+
     public bool HandleHasWindowStyle(IntPtr handle, WS style)
     {
-      var styles = unchecked((WS)GetWindowLongPtr(handle, (int)(GWL_STYLE)).ToInt64());
-
-      return (styles & style) != 0;
+      return (GetWindowStyles(handle) & style) != 0;
     }
 
     public bool HandleHasWindowExStyle(IntPtr handle, WS_EX style)
     {
-      var styles = unchecked((WS_EX)GetWindowLongPtr(handle, (int)(GWL_EXSTYLE)).ToInt64());
-
-      return (styles & style) != 0;
+      return (GetWindowStylesEx(handle) & style) != 0;
     }
 
     private IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex)

--- a/LarsWM.Domain/Workspaces/Workspace.cs
+++ b/LarsWM.Domain/Workspaces/Workspace.cs
@@ -22,12 +22,23 @@ namespace LarsWM.Domain.Workspaces
         ServiceLocator.Provider.GetRequiredService<WorkspaceService>();
 
     private int OuterGap => _userConfigService.UserConfig.Gaps.OuterGap;
-    private int BarHeight => _userConfigService.UserConfig.Bar.Height;
 
-    public override int Height => Parent.Height - (OuterGap * 2) - BarHeight;
+    /// <summary>
+    /// Get height of bar after it's been automatically adjusted by DPI scaling.
+    /// </summary>
+    private int LogicalBarHeight
+    {
+      get
+      {
+        var barHeight = _userConfigService.UserConfig.Bar.Height;
+        return Convert.ToInt32(barHeight * (Parent as Monitor).ScaleFactor);
+      }
+    }
+
+    public override int Height => Parent.Height - (OuterGap * 2) - LogicalBarHeight;
     public override int Width => Parent.Width - (OuterGap * 2);
     public override int X => Parent.X + OuterGap;
-    public override int Y => Parent.Y + OuterGap + BarHeight;
+    public override int Y => Parent.Y + OuterGap + LogicalBarHeight;
 
 
     /// <summary>

--- a/LarsWM.Infrastructure/WindowsApi/WindowsApiService.cs
+++ b/LarsWM.Infrastructure/WindowsApi/WindowsApiService.cs
@@ -287,7 +287,7 @@ namespace LarsWM.Infrastructure.WindowsApi
     public static extern int SetProcessDpiAwarenessContext(DpiAwarenessContext value);
 
     [DllImport("user32.dll", SetLastError = true)]
-    static extern int GetDpiForWindow(IntPtr hWnd);
+    public static extern uint GetDpiForWindow(IntPtr hWnd);
 
     [DllImport("user32.dll", SetLastError = true)]
     public static extern bool AdjustWindowRectEx(ref WindowRect lpRect, WS dwStyle, [MarshalAs(UnmanagedType.Bool)] bool bMenu, WS_EX dwExStyle);
@@ -308,7 +308,12 @@ namespace LarsWM.Infrastructure.WindowsApi
     [DllImport("Shcore.dll")]
     public static extern IntPtr GetDpiForMonitor(IntPtr hmonitor, DpiType dpiType, out uint dpiX, out uint dpiY);
 
+    public enum MonitorFromPointFlags : uint
+    {
+      MONITOR_DEFAULTTONEAREST = 2,
+    }
+
     [DllImport("User32.dll")]
-    public static extern IntPtr MonitorFromPoint(System.Drawing.Point pt, uint dwFlags);
+    public static extern IntPtr MonitorFromPoint(System.Drawing.Point pt, MonitorFromPointFlags dwFlags);
   }
 }

--- a/LarsWM.Infrastructure/WindowsApi/WindowsApiService.cs
+++ b/LarsWM.Infrastructure/WindowsApi/WindowsApiService.cs
@@ -269,5 +269,46 @@ namespace LarsWM.Infrastructure.WindowsApi
 
     [DllImport("user32.dll", CharSet = CharSet.Auto)]
     public static extern IntPtr SendMessage(IntPtr hWnd, SendMessageType Msg, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool IsProcessDPIAware();
+
+    public enum DpiAwarenessContext
+    {
+      Context_Undefined = 0,
+      Context_Unaware = -1,
+      Context_SystemAware = -2,
+      Context_PerMonitorAware = -3,
+      Context_PerMonitorAwareV2 = -4,
+      Context_UnawareGdiScaled = -5
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern int SetProcessDpiAwarenessContext(DpiAwarenessContext value);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    static extern int GetDpiForWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool AdjustWindowRectEx(ref WindowRect lpRect, WS dwStyle, [MarshalAs(UnmanagedType.Bool)] bool bMenu, WS_EX dwExStyle);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool AdjustWindowRect(ref WindowRect lpRect, WS dwStyle, [MarshalAs(UnmanagedType.Bool)] bool bMenu);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool AdjustWindowRectExForDpi(ref WindowRect lpRect, WS dwStyle, [MarshalAs(UnmanagedType.Bool)] bool bMenu, WS_EX dwExStyle, uint dpi);
+
+    public enum DpiType
+    {
+      Effective = 0,
+      Angular = 1,
+      Raw = 2,
+    }
+
+    [DllImport("Shcore.dll")]
+    public static extern IntPtr GetDpiForMonitor(IntPtr hmonitor, DpiType dpiType, out uint dpiX, out uint dpiY);
+
+    [DllImport("User32.dll")]
+    public static extern IntPtr MonitorFromPoint(System.Drawing.Point pt, uint dwFlags);
   }
 }


### PR DESCRIPTION
* Scale window width and height up/down if there's a mismatch in the DPI of the monitor and the DPI of the window.
* Set process DPI awareness to `PerMonitorAwareV2`.
* Handle DPI scaling of the bar window. Use `MoveWindow` to manually size and position the WPF window.