### PR TITLE
feat: move all window to specific workspace

### DIFF
--- a/packages/wm/src/app_command.rs
+++ b/packages/wm/src/app_command.rs
@@ -25,8 +25,9 @@ use crate::{
   user_config::{FloatingStateConfig, FullscreenStateConfig, UserConfig},
   windows::{
     commands::{
-      ignore_window, move_window_in_direction, move_window_to_workspace,
-      resize_window, set_window_size, update_window_state,
+      ignore_window, move_all_window_to_workspace,
+      move_window_in_direction, move_window_to_workspace, resize_window,
+      set_window_size, update_window_state,
     },
     traits::WindowGetters,
     WindowState,
@@ -188,6 +189,7 @@ pub enum InvokeCommand {
     #[clap(long)]
     direction: Direction,
   },
+  MoveAll(InvokeMoveCommand),
   Resize(InvokeResizeCommand),
   SetFloating {
     #[clap(long, default_missing_value = "true", require_equals = true, num_args = 0..=1)]
@@ -342,6 +344,22 @@ impl InvokeCommand {
       InvokeCommand::Ignore => {
         match subject_container.as_window_container() {
           Ok(window) => ignore_window(window, state),
+          _ => Ok(()),
+        }
+      }
+      InvokeCommand::MoveAll(args) => {
+        match subject_container.as_window_container() {
+          Ok(window) => {
+            if let Some(name) = &args.workspace {
+              move_all_window_to_workspace(
+                window.clone(),
+                WorkspaceTarget::Name(name.to_string()),
+                state,
+                config,
+              )?;
+            };
+            Ok(())
+          }
           _ => Ok(()),
         }
       }

--- a/packages/wm/src/windows/commands/move_window_to_workspace.rs
+++ b/packages/wm/src/windows/commands/move_window_to_workspace.rs
@@ -13,6 +13,28 @@ use crate::{
   workspaces::{commands::activate_workspace, WorkspaceTarget},
 };
 
+pub fn move_all_window_to_workspace(
+  window: WindowContainer,
+  target: WorkspaceTarget,
+  state: &mut WmState,
+  config: &UserConfig,
+) -> anyhow::Result<()> {
+  let current_workspace = window.workspace().context("No workspace.")?;
+  let _ = current_workspace
+    .children()
+    .into_iter()
+    .try_for_each(|child| {
+      let child_container = child.as_window_container()?;
+      move_window_to_workspace(
+        child_container,
+        target.clone(),
+        state,
+        config,
+      )
+    });
+  Ok(())
+}
+
 pub fn move_window_to_workspace(
   window: WindowContainer,
   target: WorkspaceTarget,

--- a/packages/wm/src/workspaces/workspace_target.rs
+++ b/packages/wm/src/workspaces/workspace_target.rs
@@ -1,5 +1,6 @@
 use crate::common::Direction;
 
+#[derive(Clone)]
 pub enum WorkspaceTarget {
   Name(String),
   Recent,


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->
#750 

This PR implements a new feature allowing users to move all windows to a specified workspace using custom key bindings. 

usage:
```
  - commands: ["move-all --workspace 1"]
    bindings: ["alt+q+1"]
```