### PR TITLE
bug: Adds `fork-user` to winget workflow

### DIFF
--- a/.github/workflows/winget-release.yaml
+++ b/.github/workflows/winget-release.yaml
@@ -14,3 +14,4 @@ jobs:
           identifier: glzr-io.glazewm
           installers-regex: 'glazewm-v[0-9.]+\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}
+          fork-user: glzr-io


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->

Sine the PAT is done by a private user i.e. `lars-berger`, it is searching for a `winget-pkgs` fork on that account. It should now point to the correct fork which is on the `glzr-io` account.
