### PR TITLE
Optionally prevent centering of floating windows on display changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ general:
   # workspace when focusing the current workspace.
   toggle_workspace_on_refocus: false
 
+  # GlazeWM, by default, centers all floating windows when
+  # connecting/disconnecting monitors. When working with many floating windows,
+  # this could disturb your workflow. Setting this to true will try to leave
+  # floating windows at their current position at the price of having windows
+  # partly off the screen when switching to a lower resolution monitor.
+  prevent_centering_of_floating_windows: false
+
   cursor_jump:
     # Whether to automatically move the cursor on the specified trigger.
     enabled: true

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -93,6 +93,10 @@ pub struct GeneralConfig {
 
   /// Affects which windows get shown in the native Windows taskbar.
   pub show_all_in_taskbar: bool,
+
+  /// Whether to prevent glazewm from centering the floating placement of all
+  /// windows in case of suspected monitor change.
+  pub prevent_centering_of_floating_windows: bool,
 }
 
 impl Default for GeneralConfig {
@@ -106,6 +110,7 @@ impl Default for GeneralConfig {
       config_reload_commands: vec![],
       hide_method: HideMethod::Cloak,
       show_all_in_taskbar: false,
+      prevent_centering_of_floating_windows: false,
     }
   }
 }

--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -18,6 +18,13 @@ general:
   # workspace when focusing the current workspace.
   toggle_workspace_on_refocus: false
 
+  # GlazeWM, by default, centers all floating windows when
+  # connecting/disconnecting monitors. When working with many floating windows,
+  # this could disturb your workflow. Setting this to true will try to leave
+  # floating windows at their current position at the price of having windows
+  # partly off the screen when switching to a lower resolution monitor.
+  prevent_centering_of_floating_windows: false
+
   cursor_jump:
     # Whether to automatically move the cursor on the specified trigger.
     enabled: true


### PR DESCRIPTION
Fix: #668.

> Note: the PR origin is from the stable TAG. I didn't know if the later commit is stable and I needed something I can trust that it's working. If needed I'll merge _main_ into it. This is why it's a Draft PR.

### Motivation:

I've started using GlazeWM a couple of weeks ago. I was looking for a way to use mostly floating windows, but for specific cases, I wanted to be able to tile the windows and get the full experience of a tiling window manager. GlazeWM exceeded my expectations. One big problem was that maybe because of my USB switcher or my keyboard, several times a day all my floating windows got centered. Every time the computer went to sleep, or I would switch to my work laptop, or even just because :slightly_frowning_face:, All my windows would become centered. This really disturbed my workflow for such extent that I decided to look for a solution. 

Please note that while I have some experience with Rust, I have zero experience in desktop programing and architecture so I may have missed many things completely.

### My suggestion:

 I checked two areas of the code. The `event_window_proc` function where events are filtered and the `handle_display_settings_changed` where the windows get centered. I printed out all the events while connecting/disconnecting devices and monitors, but while I could reduce the number of windows centering occurrences if I disabled `WM_DEVICECHANGE`, it didn't completely stop the false identification of display changes, so I figured out I need to look at the 'handle_display_settings_changed' function. Here's the [code](https://github.com/glzr-io/glazewm/blob/6242f8a0c5754007c6b286bcf6a555f328c1c829/packages/wm/src/events/handle_display_settings_changed.rs#L119-L128):

```rust
    // Need to update floating position of moved windows when a monitor is
    // disconnected or if the primary display is changed. The primary
    // display dictates the position of 0,0.
    let workspace = window.workspace().context("No workspace.")?;
    window.set_floating_placement(
      window
        .floating_placement()
        .translate_to_center(&workspace.to_rect()?),
    );
  }
```
It seems to me that it automatically centers the floating position of all windows in `state.windows()` (which in my tests result in all windows, not just the moved ones (and I wrong?) - the comment may be a little misleading). Since I'm a new user of GlazeWM, I trust that this is for a good reason, However, I wanted to allow users to disable this behavior at the possible price of having windows be partly off-screen if disconnecting from a higher resolution monitor.

I've added a new config option `prevent_centering_of_floating_windows` which default to `false` (current behavior) but when set to true, tries to leave windows where they are and move only windows that are completely off-screen.

If this is acceptable, I also want to extract two functions from the `handle_display_settings_changed` function (one that handles state workspace updates and the second that handles the windows) because it seems that they are independent of each other.

One last note, there's always the option to do a much deeper change and add to the windows metadata the `Rect` relation to the parent workspace so a window will not get moved unless it really changed to a monitor with different size, but I think the current suggestion is probably good enough to start with. 

And thanks again for this project.

