### PR TITLE
fix: "No displayed workspace" after waking up from sleep

### DIFF
--- a/packages/wm/src/commands/monitor/add_monitor.rs
+++ b/packages/wm/src/commands/monitor/add_monitor.rs
@@ -90,11 +90,6 @@ pub fn move_workspace_to_monitor(
 ) -> anyhow::Result<()> {
   let origin_monitor = workspace.monitor().context("No monitor.")?;
 
-  // Get currently displayed workspace on the target monitor.
-  let displayed_workspace = target_monitor
-    .displayed_workspace()
-    .context("No displayed workspace.")?;
-
   move_container_within_tree(
     &workspace.clone().into(),
     &target_monitor.clone().into(),
@@ -115,6 +110,11 @@ pub fn move_workspace_to_monitor(
         .translate_to_center(&workspace.to_rect()?),
     );
   }
+
+  // Get currently displayed workspace on the target monitor.
+  let displayed_workspace = target_monitor
+    .displayed_workspace()
+    .context("No displayed workspace.")?;
 
   state
     .pending_sync


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->

Closes #907
Closes #1124

After the computer wakes from sleep or reconnects to a monitor, Glaze tries to add new monitors and arrange workspaces and windows. However, there’s a statement that retrieves workspace information before the arrangement, which causes the bug. Simply move that statement to run right after the workspace has been arranged.