### PR TITLE
fix: add cursor jump for `wm-cycle-focus` and window minimize

### DIFF
--- a/packages/wm/src/commands/window/move_window_in_direction.rs
+++ b/packages/wm/src/commands/window/move_window_in_direction.rs
@@ -27,7 +27,6 @@ pub fn move_window_in_direction(
   state: &mut WmState,
   config: &UserConfig,
 ) -> anyhow::Result<()> {
-  state.pending_sync.queue_cursor_jump();
   match window {
     WindowContainer::TilingWindow(window) => {
       move_tiling_window(window, direction, state, config)

--- a/packages/wm/src/commands/window/update_window_state.rs
+++ b/packages/wm/src/commands/window/update_window_state.rs
@@ -111,8 +111,7 @@ fn set_tiling(
   state
     .pending_sync
     .queue_containers_to_redraw(target_parent.tiling_children())
-    .queue_workspace_to_reorder(workspace)
-    .queue_cursor_jump();
+    .queue_workspace_to_reorder(workspace);
 
   Ok(tiling_window.into())
 }
@@ -138,7 +137,6 @@ fn set_non_tiling(
     return Ok(window);
   }
 
-  state.pending_sync.queue_cursor_jump();
   let workspace = window.workspace().context("No workspace.")?;
 
   match window {

--- a/packages/wm/src/events/handle_window_minimized.rs
+++ b/packages/wm/src/events/handle_window_minimized.rs
@@ -36,7 +36,7 @@ pub fn handle_window_minimized(
       if let Some(focus_target) = state.focus_target_after_removal(&window)
       {
         set_focused_descendant(&focus_target, None);
-        state.pending_sync.queue_focus_change();
+        state.pending_sync.queue_focus_change().queue_cursor_jump();
         state.unmanaged_or_minimized_timestamp =
           Some(std::time::Instant::now());
       }


### PR DESCRIPTION
This PR closes #884 and expands it to more events.
The `cursor_jump` configuration setting was previously not triggering on various occasions. This is especially annoying when mixed with the `focus_follows_cursor`-option for options which move the position of the active window, if the cursor then automatically focuses a different window. This PR thus adds cursor jump for multiple events:
- cycling focus
- moving window in direction
- toggling tiling
- focusing floating window