### PR TITLE
fix: missing `queue_cursor_jump()` when moving window to sibling containers

### DIFF
--- a/packages/wm/src/commands/window/move_window_in_direction.rs
+++ b/packages/wm/src/commands/window/move_window_in_direction.rs
@@ -162,7 +162,8 @@ fn move_to_sibling_container(
       state
         .pending_sync
         .queue_container_to_redraw(sibling_window)
-        .queue_container_to_redraw(window_to_move);
+        .queue_container_to_redraw(window_to_move)
+        .queue_cursor_jump();
     }
     TilingContainer::Split(sibling_split) => {
       let sibling_descendant =
@@ -197,7 +198,8 @@ fn move_to_sibling_container(
         state
           .pending_sync
           .queue_container_to_redraw(target_parent)
-          .queue_containers_to_redraw(parent.tiling_children());
+          .queue_containers_to_redraw(parent.tiling_children())
+          .queue_cursor_jump();
       }
     }
   }


### PR DESCRIPTION
This PR fixes an issue where moving a window within the same workspace does not trigger a cursor jump, even with the `cursor_jump` feature enabled.

PS: First time contributing to this project and working on any rust project in general. Please let me know in case of any issues with the PR and looking forward to this fix being merged if possible. 