### PR TITLE
fix: monitor disconnect/reconnect issues

### DIFF
--- a/packages/wm/src/commands/general/platform_sync.rs
+++ b/packages/wm/src/commands/general/platform_sync.rs
@@ -245,6 +245,11 @@ fn redraw_containers(
 
     // Transition display state depending on whether window will be
     // shown or hidden.
+    let is_transitioning_to_shown = matches!(
+      window.display_state(),
+      DisplayState::Hidden | DisplayState::Hiding
+    ) && workspace.is_displayed();
+
     window.set_display_state(
       match (window.display_state(), workspace.is_displayed()) {
         (DisplayState::Hidden | DisplayState::Hiding, true) => {
@@ -256,6 +261,14 @@ fn redraw_containers(
         _ => window.display_state(),
       },
     );
+
+    // Refresh minimized/maximized state when transitioning from hidden to
+    // shown. Windows may have minimized the window during monitor
+    // disconnect, and we need the current state to properly restore it.
+    if is_transitioning_to_shown {
+      let _ = window.native().refresh_is_minimized();
+      let _ = window.native().refresh_is_maximized();
+    }
 
     let rect = window
       .to_rect()?


### PR DESCRIPTION
## Summary

Fixes several issues when disconnecting and reconnecting monitors, specifically the 'No displayed workspace' error that requires restarting GlazeWM.

## Changes

### 1. Fix 'No displayed workspace' error on monitor reconnect
- Handle case where target monitor has no workspaces yet when moving bound workspaces back
- Make origin monitor `displayed_workspace()` check non-fatal

### 2. Fix bind_to_monitor rules ignored after reconnect
- Sort monitors by physical position before checking `bind_to_monitor` indices
- Ensures correct workspace-to-monitor binding based on actual monitor positions

### 3. Fix windows minimized when switching to workspace from disconnected monitor
- Refresh cached minimized/maximized state when windows transition from hidden to shown
- Windows now properly restore their state instead of remaining minimized

### 4. Fix focus unexpectedly shifts to reconnected monitor
- Preserve focused container before workspace moves
- Restore focus after reconnection completes, preventing unwanted focus shifts

## Testing

Tested with dual monitor setup:
1. Turn off secondary monitor → workspaces move to primary ✓
2. Switch to workspace from disconnected monitor → windows visible (not minimized) ✓
3. Turn on secondary monitor → bound workspaces return to correct monitor ✓
4. Focus stays on primary monitor (doesn't jump to reconnected monitor, given that last focused workspace is bound to primary monitor) ✓

## Related Issues

Fixes #1233