### PR TITLE
fix: explorer restart fix due to COM interface becoming stale

### DIFF
--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -341,13 +341,13 @@ impl MatchType {
     match self {
       MatchType::Equals { equals } => value == equals,
       MatchType::Includes { includes } => value.contains(includes),
-      MatchType::Regex { regex } => regex::Regex::new(regex)
-        .map(|re| re.is_match(value))
-        .unwrap_or(false),
+      MatchType::Regex { regex } => {
+        regex::Regex::new(regex).is_ok_and(|re| re.is_match(value))
+      }
       MatchType::NotEquals { not_equals } => value != not_equals,
-      MatchType::NotRegex { not_regex } => regex::Regex::new(not_regex)
-        .map(|re| !re.is_match(value))
-        .unwrap_or(false),
+      MatchType::NotRegex { not_regex } => {
+        regex::Regex::new(not_regex).is_ok_and(|re| !re.is_match(value))
+      }
     }
   }
 }

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -559,8 +559,7 @@ impl WmState {
       .filter(|descendant| {
         descendant
           .to_rect()
-          .map(|rect| rect.contains_point(point))
-          .unwrap_or(false)
+          .is_ok_and(|rect| rect.contains_point(point))
       })
       .collect()
   }
@@ -573,8 +572,7 @@ impl WmState {
       .find(|monitor| {
         monitor
           .to_rect()
-          .map(|rect| rect.contains_point(point))
-          .unwrap_or(false)
+          .is_ok_and(|rect| rect.contains_point(point))
       })
       .cloned()
   }


### PR DESCRIPTION
- fixes cached COM interface becoming stale after explorer restart
- fixes windows not cloaking properly if explorer was restarted (manually or due to a crash)
- fixes clippy warnings