### PR TITLE
feat: workspace IPC and navigation updates

### DIFF
--- a/packages/wm-common/src/dtos/workspace_dto.rs
+++ b/packages/wm-common/src/dtos/workspace_dto.rs
@@ -13,6 +13,8 @@ pub struct WorkspaceDto {
   pub id: Uuid,
   pub name: String,
   pub display_name: Option<String>,
+  pub keep_alive: bool,
+  pub bind_to_monitor: Option<u32>,
   pub parent_id: Option<Uuid>,
   pub children: Vec<ContainerDto>,
   pub child_focus_order: Vec<Uuid>,

--- a/packages/wm/src/commands/general/reload_config.rs
+++ b/packages/wm/src/commands/general/reload_config.rs
@@ -3,7 +3,10 @@ use tracing::{info, warn};
 use wm_common::{HideMethod, ParsedConfig, WindowRuleEvent, WmEvent};
 
 use crate::{
-  commands::{window::run_window_rules, workspace::sort_workspaces},
+  commands::{
+    window::run_window_rules,
+    workspace::{activate_keep_alive_workspaces, sort_workspaces},
+  },
   traits::{CommonGetters, TilingSizeGetters, WindowGetters},
   user_config::UserConfig,
   wm::WindowManager,
@@ -29,6 +32,12 @@ pub fn reload_config(
   }
 
   update_workspace_configs(state, config)?;
+
+  let fallback_monitor = state
+    .focused_container()
+    .and_then(|focused| focused.monitor());
+
+  activate_keep_alive_workspaces(state, config, fallback_monitor)?;
 
   update_container_gaps(state, config);
 

--- a/packages/wm/src/models/workspace.rs
+++ b/packages/wm/src/models/workspace.rs
@@ -89,6 +89,8 @@ impl Workspace {
       id: self.id(),
       name: config.name,
       display_name: config.display_name,
+      keep_alive: config.keep_alive,
+      bind_to_monitor: config.bind_to_monitor,
       parent_id: self.parent().map(|parent| parent.id()),
       children,
       child_focus_order: self.0.borrow().child_focus_order.clone().into(),

--- a/packages/wm/src/models/workspace_target.rs
+++ b/packages/wm/src/models/workspace_target.rs
@@ -5,6 +5,8 @@ pub enum WorkspaceTarget {
   Recent,
   NextActive,
   PreviousActive,
+  NextPopulated,
+  PreviousPopulated,
   NextActiveInMonitor,
   PreviousActiveInMonitor,
   Next,

--- a/packages/wm/src/wm.rs
+++ b/packages/wm/src/wm.rs
@@ -271,6 +271,14 @@ impl WindowManager {
           focus_workspace(WorkspaceTarget::PreviousActive, state, config)?;
         }
 
+        if args.next_populated_workspace {
+          focus_workspace(WorkspaceTarget::NextPopulated, state, config)?;
+        }
+
+        if args.prev_populated_workspace {
+          focus_workspace(WorkspaceTarget::PreviousPopulated, state, config)?;
+        }
+
         if args.next_workspace {
           focus_workspace(WorkspaceTarget::Next, state, config)?;
         }


### PR DESCRIPTION
## Summary

Improve workspace IPC data for third-party clients and add focus commands that skip empty workspaces.

## Problem

Third-party widgets need a reliable IPC source for keep-alive workspaces and display names without parsing config. Users navigating with next/prev active workspaces also need to skip empty workspaces when keep_alive is enabled.

## Solution

- IPC: add query workspaces --include-empty to include keep_alive empty workspaces.
- IPC: enrich workspace payload with keep_alive and bind_to_monitor.
- Focus: add `focus --next-populated-workspace` and `focus --prev-populated-workspace`.
- Lifecycle: activate `keep_alive` workspaces on startup and config reload.

## Testing

- cargo build -p wm
- cargo run -p wm
- Manual: (path to run local build - `target/debug/glazewm.exe`)
  - glazewm query workspaces --include-empty
  - glazewm command focus --next-populated-workspace
  - glazewm command focus --prev-populated-workspace

## References

- YASB PR: https://github.com/amnweb/yasb/pull/679
