### PR TITLE
fix: mark window as having custom placement if `centered: false`

### DIFF
--- a/packages/wm/src/commands/window/manage_window.rs
+++ b/packages/wm/src/commands/window/manage_window.rs
@@ -235,7 +235,7 @@ fn create_window(
       border_delta,
       None,
       floating_placement,
-      false,
+      !prefers_centered,
       Vec::new(),
       None,
     )


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->
A solution suggested to me by @lars-berger as a possible alternative to #1166. This is the part I care about the most from that PR. 

**Description:**

The current default behavior for floating windows is that if the window was not moved since launched, it will get centered occasionally because of device connect/disconnect events. If however, the user has moved the window, it has a flag set so it will not get centered. This PR sets the default `has_custom_floating_placement` flag to be true, provided that the user has configured floating centered to be false (like this):

```yaml
window_behavior:
  initial_state: "floating"
  state_defaults:
    floating:
      centered: false
```

For context see [this comment](https://github.com/glzr-io/glazewm/pull/1166#issuecomment-3703846837) from the original PR. 

Thanks