### PR TITLE
fix: periodically re-register keyboard hook and clear DPI flag

### DIFF
--- a/packages/wm-platform/src/keybinding_listener.rs
+++ b/packages/wm-platform/src/keybinding_listener.rs
@@ -126,6 +126,14 @@ impl KeybindingListener {
     self.enabled.store(enabled, Ordering::Relaxed);
   }
 
+  /// Re-registers the underlying keyboard hook.
+  ///
+  /// Call after system events that may silently unregister
+  /// `WH_KEYBOARD_LL` hooks (e.g. sleep/wake, display changes).
+  pub fn rehook(&mut self) -> crate::Result<()> {
+    self.keyboard_hook.rehook()
+  }
+
   /// Terminates the keybinding listener.
   pub fn terminate(&mut self) -> crate::Result<()> {
     self.keyboard_hook.terminate()

--- a/packages/wm-platform/src/platform_impl/macos/keyboard_hook.rs
+++ b/packages/wm-platform/src/platform_impl/macos/keyboard_hook.rs
@@ -103,6 +103,15 @@ impl KeyboardHook {
     })
   }
 
+  /// Re-registers the keyboard hook.
+  ///
+  /// On macOS, `CGEventTap` hooks are not silently unregistered by the OS
+  /// (unlike `WH_KEYBOARD_LL` on Windows), so this is a no-op.
+  #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
+  pub fn rehook(&mut self) -> crate::Result<()> {
+    Ok(())
+  }
+
   /// Terminates the keyboard hook by invalidating the event tap.
   #[allow(clippy::unnecessary_wraps)]
   pub fn terminate(&mut self) -> crate::Result<()> {

--- a/packages/wm-platform/src/platform_impl/windows/keyboard_hook.rs
+++ b/packages/wm-platform/src/platform_impl/windows/keyboard_hook.rs
@@ -144,6 +144,30 @@ impl KeyboardHook {
     Ok(())
   }
 
+  /// Re-registers the keyboard hook with the existing callback.
+  ///
+  /// Windows can silently unregister `WH_KEYBOARD_LL` hooks after
+  /// system events (sleep/wake, lock screen, UAC). This method
+  /// unhooks the old handle and installs a fresh one, reusing the
+  /// callback already stored in the thread-local.
+  pub fn rehook(&mut self) -> crate::Result<()> {
+    // Unhook the (possibly dead) old handle; ignore errors since
+    // it may already be invalid.
+    let _ = unsafe { UnhookWindowsHookEx(self.handle) };
+
+    let new_handle = self.dispatcher.dispatch_sync(|| unsafe {
+      SetWindowsHookExW(
+        WH_KEYBOARD_LL,
+        Some(Self::hook_proc),
+        HINSTANCE::default(),
+        0,
+      )
+    })??;
+
+    self.handle = new_handle;
+    Ok(())
+  }
+
   /// Hook procedure for keyboard events.
   ///
   /// For use with `SetWindowsHookExW`.

--- a/packages/wm/src/commands/general/platform_sync.rs
+++ b/packages/wm/src/commands/general/platform_sync.rs
@@ -453,6 +453,7 @@ fn reposition_window(
           // first move are resolved.
           if window.has_pending_dpi_adjustment() {
             window.native().set_window_pos(z_order, &rect, swp_flags)?;
+            window.set_has_pending_dpi_adjustment(false);
           }
         }
       }

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -210,6 +210,13 @@ async fn start_wm(
         wm.process_event(PlatformEvent::Keybinding(event), &mut config)
       }
       _ = cleanup_interval.tick() => {
+        // Re-register keyboard hook — Windows silently drops
+        // WH_KEYBOARD_LL hooks after system events (sleep/wake,
+        // lock screen, UAC, display changes, hook timeout).
+        if let Err(err) = keybinding_listener.rehook() {
+          tracing::warn!("Failed to re-register keyboard hook: {}", err);
+        }
+
         if wm.state.is_paused {
           Ok(())
         } else {


### PR DESCRIPTION
## Summary

- Windows silently unregisters `WH_KEYBOARD_LL` hooks after sleep/wake, lock screen, UAC prompts, and hook timeout. This caused keybindings to stop working until glazewm was restarted.
- Fix: call `keybinding_listener.rehook()` on each 5-second cleanup tick, reinstalling the hook within 5 seconds of any trigger.
- Also clears `has_pending_dpi_adjustment` on windows that no longer need it, preventing stale redraw flags from accumulating.

## Test plan

- [ ] Lock the screen or sleep/wake the PC and verify keybindings continue to work within ~5 seconds of resuming.
- [ ] Confirm `cargo clippy` passes with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)