### PR TITLE
fix: update objc2 dependencies for macOS 26 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,18 +1516,18 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-application-services"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9abc05b1f757ebfbd72f4f3f9a515662c67dfe66b26e71b37d818f56a1c2f17"
+checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -1553,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.9.1",
  "block2",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.9.1",
  "block2",
@@ -1582,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-core-services"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159be6e4cd366c7d236d798daa2aa71855230e5691cde045a0670ce01a06d664"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
 dependencies = [
  "dispatch2",
  "objc2",
@@ -1600,9 +1600,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.9.1",
  "block2",
@@ -1612,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-io-surface"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.9.1",
  "objc2",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-metal"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f246c183239540aab1782457b35ab2040d4259175bd1d0c58e46ada7b47a874"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.9.1",
  "objc2",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-security"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8e0ef3ab66b08c42644dcb34dba6ec0a574bbd8adbb8bdbdc7a2779731a44"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.9.1",
  "objc2",

--- a/packages/wm-platform/Cargo.toml
+++ b/packages/wm-platform/Cargo.toml
@@ -49,9 +49,9 @@ windows = { version = "0.52", features = [
 windows-interface = { version = "0.52" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-core-graphics = "0.3.1"
-objc2 = "0.6.1"
-objc2-app-kit = { version = "0.3.1", default-features = false, features = [
+objc2-core-graphics = "0.3.2"
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
   "NSAlert",
   "NSApplication",
   "NSEvent",
@@ -64,12 +64,12 @@ objc2-app-kit = { version = "0.3.1", default-features = false, features = [
   "libc",
   "objc2-core-foundation",
 ] }
-objc2-application-services = "0.3.1"
-objc2-core-foundation = { version = "0.3.1", features = [
+objc2-application-services = "0.3.2"
+objc2-core-foundation = { version = "0.3.2", features = [
   "CFCGTypes",
   "CFUUID",
 ] }
-objc2-foundation = { version = "0.3.1", default-features = false, features = [
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
   "NSArray",
   "NSEnumerator",
   "NSNotification",

--- a/packages/wm-platform/src/dispatcher.rs
+++ b/packages/wm-platform/src/dispatcher.rs
@@ -554,8 +554,8 @@ impl Dispatcher {
   pub fn cursor_position(&self) -> crate::Result<Point> {
     #[cfg(target_os = "macos")]
     {
-      let event = unsafe { CGEvent::new(None) };
-      let point = unsafe { CGEvent::location(event.as_deref()) };
+      let event = CGEvent::new(None);
+      let point = CGEvent::location(event.as_deref());
 
       #[allow(clippy::cast_possible_truncation)]
       Ok(Point {
@@ -586,7 +586,7 @@ impl Dispatcher {
       };
 
       // Check if bit at corresponding index is set in the bitmask.
-      let pressed_mask = unsafe { NSEvent::pressedMouseButtons() };
+      let pressed_mask = NSEvent::pressedMouseButtons();
       (pressed_mask & (1usize << bit_index)) != 0
     }
     #[cfg(target_os = "windows")]
@@ -620,7 +620,7 @@ impl Dispatcher {
         y: f64::from(point.y),
       };
 
-      if unsafe { CGWarpMouseCursorPosition(point) } != CGError::Success {
+      if CGWarpMouseCursorPosition(point) != CGError::Success {
         return Err(crate::Error::Platform(
           "Failed to set cursor position.".to_string(),
         ));
@@ -692,13 +692,11 @@ impl Dispatcher {
       let _ = self.dispatch_sync(|| {
         let mtm = MainThreadMarker::new().unwrap();
 
-        unsafe {
-          let alert = NSAlert::new(mtm);
-          alert.setMessageText(&NSString::from_str(title));
-          alert.setInformativeText(&NSString::from_str(message));
-          alert.setAlertStyle(NSAlertStyle::Critical);
-          alert.runModal();
-        };
+        let alert = NSAlert::new(mtm);
+        alert.setMessageText(&NSString::from_str(title));
+        alert.setInformativeText(&NSString::from_str(message));
+        alert.setAlertStyle(NSAlertStyle::Critical);
+        alert.runModal();
       });
     }
   }

--- a/packages/wm-platform/src/platform_impl/macos/application.rs
+++ b/packages/wm-platform/src/platform_impl/macos/application.rs
@@ -30,7 +30,7 @@ impl Application {
     ns_app: Retained<NSRunningApplication>,
     dispatcher: Dispatcher,
   ) -> Self {
-    let pid = unsafe { ns_app.processIdentifier() };
+    let pid = ns_app.processIdentifier();
     let ax_element = Arc::new(ThreadBound::new(
       // Creation of `AXUIElement` for an application does not fail even
       // if the PID is invalid. Instead, subsequent operations on
@@ -94,12 +94,16 @@ impl Application {
   }
 
   pub fn bundle_id(&self) -> Option<String> {
-    unsafe { self.ns_app.bundleIdentifier() }
+    self
+      .ns_app
+      .bundleIdentifier()
       .map(|ns_string| ns_string.to_string())
   }
 
   pub fn process_name(&self) -> Option<String> {
-    unsafe { self.ns_app.localizedName() }
+    self
+      .ns_app
+      .localizedName()
       .map(|ns_string| ns_string.to_string())
   }
 
@@ -132,7 +136,7 @@ impl Application {
   }
 
   pub fn activation_policy(&self) -> NSApplicationActivationPolicy {
-    unsafe { self.ns_app.activationPolicy() }
+    self.ns_app.activationPolicy()
   }
 
   /// Whether the application should be observed.
@@ -147,7 +151,7 @@ impl Application {
   }
 
   pub(crate) fn is_hidden(&self) -> bool {
-    unsafe { self.ns_app.isHidden() }
+    self.ns_app.isHidden()
   }
 }
 
@@ -156,7 +160,7 @@ pub(crate) fn all_applications(
 ) -> crate::Result<Vec<Application>> {
   dispatcher.dispatch_sync(|| {
     let running_apps =
-      unsafe { NSWorkspace::sharedWorkspace().runningApplications() };
+      NSWorkspace::sharedWorkspace().runningApplications();
 
     running_apps
       .iter()
@@ -171,11 +175,10 @@ pub(crate) fn application_for_bundle_id(
 ) -> crate::Result<Option<Application>> {
   let bundle_id = bundle_id.to_owned();
   dispatcher.dispatch_sync(|| {
-    let apps = unsafe {
+    let apps =
       NSRunningApplication::runningApplicationsWithBundleIdentifier(
         &NSString::from_str(&bundle_id),
-      )
-    };
+      );
 
     apps
       .into_iter()

--- a/packages/wm-platform/src/platform_impl/macos/display.rs
+++ b/packages/wm-platform/src/platform_impl/macos/display.rs
@@ -53,7 +53,7 @@ impl Display {
   /// Implements [`Display::name`].
   pub(crate) fn name(&self) -> crate::Result<String> {
     self.ns_screen.with(|screen| {
-      let name = unsafe { screen.localizedName() };
+      let name = screen.localizedName();
       Ok(name.to_string())
     })?
   }
@@ -61,7 +61,7 @@ impl Display {
   /// Implements [`Display::bounds`].
   #[allow(clippy::unnecessary_wraps)]
   pub(crate) fn bounds(&self) -> crate::Result<Rect> {
-    let cg_rect = unsafe { CGDisplayBounds(self.cg_display_id) };
+    let cg_rect = CGDisplayBounds(self.cg_display_id);
 
     #[allow(clippy::cast_possible_truncation)]
     Ok(Rect::from_xy(
@@ -75,7 +75,7 @@ impl Display {
   /// Implements [`Display::working_area`].
   pub(crate) fn working_area(&self) -> crate::Result<Rect> {
     let primary_display_bounds = {
-      let bounds = unsafe { CGDisplayBounds(CGMainDisplayID()) };
+      let bounds = CGDisplayBounds(CGMainDisplayID());
 
       #[allow(clippy::cast_possible_truncation)]
       Rect::from_xy(
@@ -115,7 +115,7 @@ impl Display {
   /// Implements [`Display::is_primary`].
   #[allow(clippy::unnecessary_wraps)]
   pub(crate) fn is_primary(&self) -> crate::Result<bool> {
-    let main_display_id = unsafe { CGMainDisplayID() };
+    let main_display_id = CGMainDisplayID();
     Ok(self.cg_display_id == main_display_id)
   }
 
@@ -229,19 +229,17 @@ impl DisplayDevice {
   #[allow(clippy::unnecessary_wraps)]
   pub(crate) fn rotation(&self) -> crate::Result<f32> {
     #[allow(clippy::cast_possible_truncation)]
-    Ok(unsafe { CGDisplayRotation(self.cg_display_id) } as f32)
+    Ok(CGDisplayRotation(self.cg_display_id) as f32)
   }
 
   /// Implements [`DisplayDevice::refresh_rate`].
   pub(crate) fn refresh_rate(&self) -> crate::Result<f32> {
     // NOTE: Calling `CGDisplayModeRelease` on cleanup is not needed, since
     // it's equivalent to `CFRelease` in this case. Ref: https://developer.apple.com/documentation/coregraphics/cgdisplaymoderelease
-    let display_mode =
-      unsafe { CGDisplayCopyDisplayMode(self.cg_display_id) }
-        .ok_or(crate::Error::DisplayModeNotFound)?;
+    let display_mode = CGDisplayCopyDisplayMode(self.cg_display_id)
+      .ok_or(crate::Error::DisplayModeNotFound)?;
 
-    let refresh_rate =
-      unsafe { CGDisplayMode::refresh_rate(Some(&display_mode)) };
+    let refresh_rate = CGDisplayMode::refresh_rate(Some(&display_mode));
 
     #[allow(clippy::cast_possible_truncation)]
     Ok(refresh_rate as f32)
@@ -251,15 +249,14 @@ impl DisplayDevice {
   #[allow(clippy::unnecessary_wraps)]
   pub(crate) fn is_builtin(&self) -> crate::Result<bool> {
     // TODO: Implement this properly.
-    let main_display_id = unsafe { CGMainDisplayID() };
+    let main_display_id = CGMainDisplayID();
     Ok(self.cg_display_id == main_display_id)
   }
 
   /// Implements [`DisplayDevice::connection_state`].
   #[allow(clippy::unnecessary_wraps)]
   pub(crate) fn connection_state(&self) -> crate::Result<ConnectionState> {
-    let display_mode =
-      unsafe { CGDisplayCopyDisplayMode(self.cg_display_id) };
+    let display_mode = CGDisplayCopyDisplayMode(self.cg_display_id);
 
     // TODO: Implement this properly.
     if display_mode.is_none() {
@@ -274,8 +271,7 @@ impl DisplayDevice {
   pub(crate) fn mirroring_state(
     &self,
   ) -> crate::Result<Option<MirroringState>> {
-    let mirrored_display =
-      unsafe { CGDisplayMirrorsDisplay(self.cg_display_id) };
+    let mirrored_display = CGDisplayMirrorsDisplay(self.cg_display_id);
 
     // TODO: Clean this up.
     if mirrored_display == 0 {
@@ -300,8 +296,7 @@ impl DisplayDevice {
           if display_id == self.cg_display_id {
             continue; // Skip self
           }
-          let other_mirrored =
-            unsafe { CGDisplayMirrorsDisplay(display_id) };
+          let other_mirrored = CGDisplayMirrorsDisplay(display_id);
           if other_mirrored == self.cg_display_id {
             // Another display is mirroring this one, so this is the source
             return Ok(Some(MirroringState::Source));

--- a/packages/wm-platform/src/platform_impl/macos/event_loop.rs
+++ b/packages/wm-platform/src/platform_impl/macos/event_loop.rs
@@ -82,7 +82,7 @@ impl EventLoopSource {
 
       // `stop()` only takes effect after processing a subsequent UI event.
       // Post a dummy event so the application actually exits.
-      unsafe { ns_app.abortModal() };
+      ns_app.abortModal();
 
       let _ = result_tx.send(());
     })?;

--- a/packages/wm-platform/src/platform_impl/macos/keyboard_hook.rs
+++ b/packages/wm-platform/src/platform_impl/macos/keyboard_hook.rs
@@ -159,7 +159,7 @@ impl KeyboardHook {
     current_loop
       .add_source(Some(&loop_source), unsafe { kCFRunLoopCommonModes });
 
-    unsafe { CGEvent::tap_enable(&tap_port, true) };
+    CGEvent::tap_enable(&tap_port, true);
 
     Ok(ThreadBound::new(tap_port, dispatcher.clone()))
   }

--- a/packages/wm-platform/src/platform_impl/macos/mouse_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/mouse_listener.rs
@@ -91,7 +91,7 @@ impl MouseListener {
   /// Implements [`MouseListener::enable`].
   pub(crate) fn enable(&mut self, enabled: bool) -> crate::Result<()> {
     if let Some(tap_port) = &self.tap_port {
-      tap_port.with(|tap| unsafe { CGEvent::tap_enable(tap, enabled) })?;
+      tap_port.with(|tap| CGEvent::tap_enable(tap, enabled))?;
     }
 
     Ok(())
@@ -185,7 +185,7 @@ impl MouseListener {
     current_loop
       .add_source(Some(&loop_source), unsafe { kCFRunLoopCommonModes });
 
-    unsafe { CGEvent::tap_enable(&tap_port, true) };
+    CGEvent::tap_enable(&tap_port, true);
 
     Ok(ThreadBound::new(tap_port, dispatcher.clone()))
   }
@@ -250,7 +250,7 @@ impl MouseListener {
     // Extract the cursor position from the `CGEvent`.
     let cg_event_ref = unsafe { cg_event.as_ref() };
     let position = {
-      let cg_point = unsafe { CGEvent::location(Some(cg_event_ref)) };
+      let cg_point = CGEvent::location(Some(cg_event_ref));
 
       #[allow(clippy::cast_possible_truncation)]
       Point {
@@ -263,12 +263,10 @@ impl MouseListener {
     // the real window ID interspersed every so often. Often a 100–200ms
     // delay before the real window ID is returned.
     let window_below_cursor = {
-      let window_id = unsafe {
-        CGEvent::integer_value_field(
-          Some(cg_event_ref),
-          CGEventField::MouseEventWindowUnderMousePointer,
-        )
-      };
+      let window_id = CGEvent::integer_value_field(
+        Some(cg_event_ref),
+        CGEventField::MouseEventWindowUnderMousePointer,
+      );
 
       if window_id == 0 {
         None

--- a/packages/wm-platform/src/platform_impl/macos/native_window.rs
+++ b/packages/wm-platform/src/platform_impl/macos/native_window.rs
@@ -440,7 +440,7 @@ pub(crate) fn focused_window(
   dispatcher: &Dispatcher,
 ) -> crate::Result<crate::NativeWindow> {
   dispatcher
-    .dispatch_sync(|| unsafe {
+    .dispatch_sync(|| {
       // Get the frontmost (active) application.
       let frontmost_app = NSWorkspace::sharedWorkspace()
         .frontmostApplication()
@@ -465,11 +465,9 @@ pub(crate) fn reset_focus(dispatcher: &Dispatcher) -> crate::Result<()> {
     ));
   };
 
-  let success = unsafe {
-    application.ns_app.activateWithOptions(
-      NSApplicationActivationOptions::ActivateAllWindows,
-    )
-  };
+  let success = application.ns_app.activateWithOptions(
+    NSApplicationActivationOptions::ActivateAllWindows,
+  );
 
   if !success {
     return Err(crate::Error::Platform(

--- a/packages/wm-platform/src/platform_impl/macos/notification_center.rs
+++ b/packages/wm-platform/src/platform_impl/macos/notification_center.rs
@@ -141,7 +141,7 @@ impl NotificationObserver {
   fn handle_event(&self, notif: &NSNotification) {
     tracing::debug!("Received notification: {notif:#?}");
 
-    match NotificationName::from(unsafe { &*notif.name() }) {
+    match NotificationName::from(&*notif.name()) {
       NotificationName::WorkspaceActiveSpaceDidChange => {
         self.emit_event(NotificationEvent::WorkspaceActiveSpaceDidChange);
       }
@@ -215,14 +215,13 @@ pub(crate) struct NotificationCenter {
 
 impl NotificationCenter {
   pub fn workspace_center() -> Self {
-    let center =
-      unsafe { NSWorkspace::sharedWorkspace().notificationCenter() };
+    let center = NSWorkspace::sharedWorkspace().notificationCenter();
 
     Self { inner: center }
   }
 
   pub fn default_center() -> Self {
-    let center = unsafe { NSNotificationCenter::defaultCenter() };
+    let center = NSNotificationCenter::defaultCenter();
 
     Self { inner: center }
   }

--- a/packages/wm-platform/src/platform_impl/macos/window_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/window_listener.rs
@@ -62,7 +62,7 @@ impl WindowListener {
   ) -> crate::Result<ThreadBound<Retained<NotificationObserver>>> {
     let (observer, events_rx) = NotificationObserver::new();
 
-    let workspace = unsafe { NSWorkspace::sharedWorkspace() };
+    let workspace = NSWorkspace::sharedWorkspace();
     let mut workspace_center = NotificationCenter::workspace_center();
 
     for notification in [
@@ -158,7 +158,7 @@ impl WindowListener {
         NotificationEvent::WorkspaceDidTerminateApplication(
           running_app,
         ) => {
-          let pid = unsafe { running_app.processIdentifier() };
+          let pid = running_app.processIdentifier();
 
           if let Some(observer) = app_observers.remove(&pid) {
             tracing::info!(
@@ -188,14 +188,14 @@ impl WindowListener {
         }
         NotificationEvent::WorkspaceDidHideApplication(running_app) => {
           if let Some(app_observer) =
-            app_observers.get(unsafe { &running_app.processIdentifier() })
+            app_observers.get(&running_app.processIdentifier())
           {
             app_observer.emit_all_windows_hidden();
           }
         }
         NotificationEvent::WorkspaceDidUnhideApplication(running_app) => {
           if let Some(app_observer) =
-            app_observers.get(unsafe { &running_app.processIdentifier() })
+            app_observers.get(&running_app.processIdentifier())
           {
             app_observer.emit_all_windows_shown();
           }


### PR DESCRIPTION
## Summary

- Bumps `objc2` from 0.6.1 to 0.6.4 and all `objc2-*` framework crates from 0.3.1 to 0.3.2
- Removes unnecessary `unsafe` blocks that are no longer required in the updated API

## Problem

GlazeWM crashes on startup on macOS 26 (Tahoe) with:

```
invalid message send to -[_TtGCs23_ContiguousArrayStorageCSo8NSScreen_$
countByEnumeratingWithState:objects:count:]: expected return to have type
code 'q', but found 'Q'
```

Apple changed the return type of `countByEnumeratingWithState:objects:count:` from `NSInteger` (signed, type code `q`) to `NSUInteger` (unsigned, type code `Q`) in macOS 26. The objc2 runtime's message send verification catches this mismatch and panics.

This is a [known issue](https://github.com/madsmtm/objc2/issues/765) fixed in objc2 0.6.2+.

## Testing

Tested on macOS 26.3.1 (MacBook Pro M-series). GlazeWM starts and enumerates monitors successfully after the update.