### PR TITLE
fix: update window_title rule in window_rules in the default config

### DIFF
--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -138,7 +138,7 @@ window_rules:
       - window_process: { equals: 'zebar' }
 
       # Ignores picture-in-picture windows for browsers.
-      - window_title: { regex: '[Pp]icture.in.[Pp]icture' }
+      - window_title: { regex: '[Pp]icture.in.[Pp]icture|^(.+?)\s?•\s?(.+)$' }
         window_class: { regex: 'Chrome_WidgetWin_1|MozillaDialogClass' }
 
       # Ignore rules for various 3rd-party apps.


### PR DESCRIPTION
added regex expression to match spotify overlay title (works in the web version but I'm not sure if it'll work in the desktop version)

spotify web version shows an overlay when you leave the website, which typically has the title of:

`<song_title> • <song_artist>`.

in the default config, specifically in `window_rules` part, there is logic to handle picture-in-picture overlays, but there is no logic to handle spotify overlays, and because spotify is widely used I think it worth adding some logic to handle.

tested it in windows using chrome web browser.