### PR TITLE
feat: add ignore rule for CleanShot X to sample config

### DIFF
--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -156,7 +156,7 @@ window_rules:
         window_class: { not_regex: 'OpusApp' }
       - window_process: { equals: 'POWERPNT' }
         window_class: { not_regex: 'PPTFrameClass' }
-      - window_process: { equals: 'CleanShot X' } # CleanShot X screenshot tool for Mac https://cleanshot.com/
+      - window_process: { equals: 'CleanShot X' }
 
 binding_modes:
   # When enabled, the focused window can be resized via arrow keys or HJKL.


### PR DESCRIPTION
I'm using CleanShot X as a screenshot tool. The default interaction with CleanShot X is to attempt to tile it.

This might be useful as a default, though if you were to add a new exception every time there exists one you might end up with an infinitely long list.

I'm unsure if there's a better way to target this.