### PR TITLE
feat: add reciprocal keybind to sample config for exiting resize mode

### DIFF
--- a/resources/assets/sample-config.yaml
+++ b/resources/assets/sample-config.yaml
@@ -169,13 +169,9 @@ binding_modes:
         bindings: ['k', 'up']
       - commands: ['resize --height -2%']
         bindings: ['j', 'down']
-      # Press enter/escape to return to default keybindings.
+      # Press escape/enter/alt+r to return to default keybindings.
       - commands: ['wm-disable-binding-mode --name resize']
-        bindings: [
-          'escape',
-          'enter',
-          'alt+r' # Mirror the default keybind used to enter resizing to exit.
-        ]
+        bindings: ['escape', 'enter', 'alt+r']
 
 keybindings:
   # Shift focus in a given direction.


### PR DESCRIPTION
The default configuration provides `alt+r` as binding to enter resize mode.

In other cases like pausing the same hotkey can be used for entering and exiting. That is not the case for resize.

It might be due to an implementation detail where resizing looks like it's designed as a keybind hijack toggle instead of a mode toggle, but I didn't really poke into the source.

This addition allows the same default keybind used to enter resizing to exit.

Caveats: If you change the default keybind for entering resize, this must be kept in sync. Maybe it might make more sense to move resize from a binding mode behavior to a toggle.