### PR TITLE
fix(macos): debounce display change events to avoid stale working area

### DIFF
--- a/packages/wm-platform/src/platform_impl/macos/display_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/display_listener.rs
@@ -1,4 +1,10 @@
-use std::time::{Duration, Instant};
+use std::{
+  sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+  },
+  time::{Duration, Instant},
+};
 
 use objc2::rc::Retained;
 use tokio::sync::mpsc;
@@ -85,8 +91,21 @@ impl DisplayListener {
       // take 1-2 seconds to be reported as online.
       const WAKE_COALESCE_DURATION: Duration = Duration::from_secs(5);
 
+      // Duration to debounce display change events. macOS can fire
+      // multiple `NSApplicationDidChangeScreenParametersNotification`
+      // during a single reconfiguration, and `NSScreen.visibleFrame` may
+      // reflect a transient state (e.g. the menu bar being momentarily
+      // visible despite auto-hide being enabled). Waiting briefly ensures
+      // the display state has fully settled.
+      const DISPLAY_CHANGE_DEBOUNCE: Duration = Duration::from_millis(500);
+
       let mut is_asleep = false;
       let mut wake_time: Option<Instant> = None;
+
+      // Generation counter used to debounce rapid display change events.
+      // Each incoming event increments the counter and spawns a delayed
+      // send; only the latest generation actually delivers the event.
+      let debounce_gen = Arc::new(AtomicUsize::new(0));
 
       // Loop exits when the sender is dropped in `Self::terminate`.
       while let Some(event) = events_rx.blocking_recv() {
@@ -127,13 +146,25 @@ impl DisplayListener {
               wake_time = None;
             }
 
-            if let Err(err) = event_tx.send(()) {
-              tracing::warn!(
-                "Failed to send display change event: {}",
-                err
-              );
-              break;
-            }
+            // Debounce: increment the generation and schedule a delayed
+            // send. If another event arrives before the delay elapses,
+            // its generation will supersede this one and this send will
+            // be skipped.
+            let gen = debounce_gen.fetch_add(1, Ordering::SeqCst) + 1;
+            let gen_ref = debounce_gen.clone();
+            let tx = event_tx.clone();
+
+            std::thread::spawn(move || {
+              std::thread::sleep(DISPLAY_CHANGE_DEBOUNCE);
+
+              if gen_ref.load(Ordering::SeqCst) == gen {
+                if let Err(err) = tx.send(()) {
+                  tracing::warn!(
+                    "Failed to send display change event: {err}"
+                  );
+                }
+              }
+            });
           }
           _ => {}
         }


### PR DESCRIPTION
## Summary

- Debounce `NSApplicationDidChangeScreenParametersNotification` events with a 500ms delay to ensure `NSScreen.visibleFrame` is queried after the display state has fully settled
- Fixes an intermittent gap between the top bar and tiled windows on the primary monitor after monitor connect/disconnect

## Problem

When the macOS menu bar is set to auto-hide, it can be **momentarily visible** during display reconfiguration (monitor connect/disconnect). `NSScreen.visibleFrame` captures this transient state — including the menu bar offset (~25-37px) — and stores it as the monitor's `working_area`. Since macOS does **not** fire another notification when the menu bar re-hides, the stale offset persists, creating an unexpected gap between the bar and tiled windows on the primary monitor.

Secondary monitors are unaffected because they have no menu bar.

## Solution

Uses an atomic generation counter to debounce rapid display change events. Each incoming event increments the counter and spawns a delayed thread (500ms). Only the latest generation actually delivers the event to the handler, ensuring:

1. Multiple rapid notifications during a single reconfiguration are coalesced into one
2. `NSScreen.visibleFrame` is queried after the menu bar auto-hide animation (~250-400ms) has completed

This is the same pattern already used for wake-event coalescing (`WAKE_COALESCE_DURATION`), just with a shorter delay.

## Research

- **yabai** avoids `NSScreen` entirely, using private SkyLight/CG APIs
- **Amethyst** uses the same notification but subscribes to additional menu bar change events
- **AeroSpace** lazily re-reads `NSScreen` on every refresh session
- Apple docs confirm AppKit screen state may not be fully settled when CG-level notifications fire