### PR TITLE
fix: prevent crash on wake/startup by skipping cleanup_invalid_windows under commit pressure

### DIFF
--- a/packages/wm-platform/Cargo.toml
+++ b/packages/wm-platform/Cargo.toml
@@ -32,6 +32,7 @@ windows = { version = "0.52", features = [
   "Win32_Graphics_Gdi",
   "Win32_Security",
   "Win32_System_Com",
+  "Win32_System_SystemInformation",
   "Win32_System_Environment",
   "Win32_System_LibraryLoader",
   "Win32_System_Registry",

--- a/packages/wm-platform/src/dispatcher.rs
+++ b/packages/wm-platform/src/dispatcher.rs
@@ -26,7 +26,10 @@ use windows::{
   core::PCWSTR,
   Win32::{
     Foundation::POINT,
-    System::Environment::ExpandEnvironmentStringsW,
+    System::{
+      Environment::ExpandEnvironmentStringsW,
+      SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX},
+    },
     UI::{
       Input::KeyboardAndMouse::{
         GetAsyncKeyState, VK_LBUTTON, VK_RBUTTON,
@@ -662,6 +665,45 @@ impl Dispatcher {
     }
 
     Ok(())
+  }
+
+  /// Returns whether the system is under significant virtual-memory commit
+  /// pressure.
+  ///
+  /// On Windows, a commit pressure spike occurs immediately after wake
+  /// from sleep and during system startup as suspended processes are
+  /// paged back in. Any allocation that fails during this window causes
+  /// Rust's global allocator to call `handle_alloc_error → rust_oom →
+  /// __fastfail(7)`, terminating the process. This cannot be caught by
+  /// `catch_unwind`.
+  ///
+  /// Returns `true` when less than half of the total virtual-memory commit
+  /// limit (`ullTotalPageFile`) is available (`ullAvailPageFile`). At that
+  /// point, deferring any optional allocating work (e.g.
+  /// `cleanup_invalid_windows`) eliminates the timing window without
+  /// affecting normal operation — the next tick (5 seconds later) will
+  /// retry once pressure subsides.
+  ///
+  /// Always returns `false` on macOS and when the API call fails.
+  #[must_use]
+  pub fn is_under_commit_pressure(&self) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+      // SAFETY: `MEMORYSTATUSEX` contains only numeric fields; zeroing is
+      // valid. `dwLength` must be set to the struct size before the call.
+      let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+      status.dwLength =
+        u32::try_from(std::mem::size_of::<MEMORYSTATUSEX>())
+          .unwrap_or_default();
+
+      if unsafe { GlobalMemoryStatusEx(&raw mut status) }.is_ok()
+        && status.ullTotalPageFile > 0
+      {
+        return status.ullAvailPageFile < status.ullTotalPageFile / 2;
+      }
+    }
+
+    false
   }
 
   /// Shows a modal error dialog with the given title and message.

--- a/packages/wm-platform/src/platform_impl/windows/mouse_listener.rs
+++ b/packages/wm-platform/src/platform_impl/windows/mouse_listener.rs
@@ -186,7 +186,7 @@ impl MouseListener {
     if res_size == 0
       || raw_input_size == u32::MAX
       || raw_input.header.dwType != RIM_TYPEMOUSE.0
-      || unsafe { raw_input.data.mouse.ulExtraInformation } as u32
+      || unsafe { raw_input.data.mouse.ulExtraInformation }
         == FOREGROUND_INPUT_IDENTIFIER
     {
       return Ok(());

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -212,7 +212,15 @@ async fn start_wm(
         wm.process_event(PlatformEvent::Keybinding(event), &mut config)
       }
       _ = cleanup_interval.tick() => {
-        if wm.state.is_paused {
+        // Skip cleanup when the system is under virtual-memory commit
+        // pressure (e.g. immediately after wake from sleep or during
+        // system startup). The allocations inside `cleanup_invalid_windows`
+        // can trigger an OOM abort at exactly these moments. The work is
+        // deferred, not dropped — the next tick (5 seconds later) retries
+        // once pressure subsides.
+        if wm.state.is_paused
+          || dispatcher.is_under_commit_pressure()
+        {
           Ok(())
         } else {
           wm.state.cleanup_invalid_windows()


### PR DESCRIPTION
## Context

This fix is the result of several weeks of crash investigation on Windows. We tracked crash reports via Windows Error Reporting, collected minidumps, built a custom PDB RVA decoder to map fault offsets to source lines, and added unbuffered memory diagnostics (`GlobalMemoryStatusEx` fields written directly to `errors.log` every 5 seconds) to correlate system commit state with crash timing.

All crashes shared the same signature: exception `0xc0000409` (FAST_FAIL_FATAL_APP_EXIT), no Rust panic marker, no `catch_unwind` coverage. Heap dump analysis confirmed `rust_oom → handle_alloc_error → __fastfail(7)` as the call chain. The fix was validated over multiple days of sleep/wake cycles and system restarts without a single recurrence.

## Problem

On Windows, waking from sleep causes a transient virtual-memory commit pressure spike as the OS pages suspended processes back in. During this window, `ullAvailPageFile` drops sharply. Any heap allocation during peak pressure triggers `handle_alloc_error → rust_oom → __fastfail(7)` (exception `0xc0000409`), terminating the process. This cannot be caught by `catch_unwind`.

The cleanup tick runs `cleanup_invalid_windows` every 5 seconds. This iterates the container tree and allocates during window state management — if it fires during a pressure spike, it OOMs and crashes glazewm on every startup or wake.

Root cause was confirmed via Windows Error Reporting minidumps and a custom PDB RVA decoder. The `spawn_pipe_relay +0x2291` label seen in earlier crash reports is a **PDB nearest-symbol artifact** — `rust_oom → intrinsics::abort()` compiles to `int 0x29` at that binary address. No relay thread was ever present.

## Solution

Add `Dispatcher::is_under_commit_pressure()` to `wm-platform`, which calls `GlobalMemoryStatusEx` and returns `true` when `ullAvailPageFile < ullTotalPageFile / 2`. Returns `false` unconditionally on macOS.

When commit pressure is high, the cleanup tick skips `cleanup_invalid_windows` entirely. The work is **deferred, not dropped** — the next tick retries 5 seconds later once pressure has subsided.

## Testing

- Confirmed crash-free across dozens of sleep/wake cycles and system restarts over multiple days on a Windows 11 machine.
- `is_under_commit_pressure()` returns `false` on macOS (no-op on that platform).

## Notes

- A companion PR (#1348) adds a debounce on `DisplaySettingsChanged` using the same `is_under_commit_pressure()` API, as the handler itself can also OOM during pressure spikes.
- Also fixes a pre-existing `clippy::cast_possible_truncation` lint in `mouse_listener.rs` (`ulExtraInformation` is already `u32`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)