### PR TITLE
test: fix pre-existing unit tests

### DIFF
--- a/packages/wm-common/src/tiling_direction.rs
+++ b/packages/wm-common/src/tiling_direction.rs
@@ -16,7 +16,7 @@ impl TilingDirection {
   ///
   /// Example:
   /// ```
-  /// # use wm_platform::TilingDirection;
+  /// # use wm_common::TilingDirection;
   /// let dir = TilingDirection::Horizontal.inverse();
   /// assert_eq!(dir, TilingDirection::Vertical);
   /// ```
@@ -33,7 +33,8 @@ impl TilingDirection {
   ///
   /// Example:
   /// ```
-  /// # use wm_platform::{Direction, TilingDirection};
+  /// # use wm_common::TilingDirection;
+  /// # use wm_platform::Direction;
   /// let dir = TilingDirection::from_direction(&Direction::Left);
   /// assert_eq!(dir, TilingDirection::Horizontal);
   /// ```
@@ -53,7 +54,7 @@ impl FromStr for TilingDirection {
   ///
   /// Example:
   /// ```
-  /// # use wm_platform::TilingDirection;
+  /// # use wm_common::TilingDirection;
   /// # use std::str::FromStr;
   /// let dir = TilingDirection::from_str("horizontal");
   /// assert_eq!(dir.unwrap(), TilingDirection::Horizontal);

--- a/packages/wm-platform/src/models/key_code.rs
+++ b/packages/wm-platform/src/models/key_code.rs
@@ -258,7 +258,6 @@ mod tests {
       Key::S,
       Key::D,
       Key::F,
-      Key::Cmd,
       Key::LAlt,
       Key::RCtrl,
       Key::LShift,

--- a/packages/wm/src/events/handle_window_moved_or_resized.rs
+++ b/packages/wm/src/events/handle_window_moved_or_resized.rs
@@ -552,7 +552,7 @@ mod tests {
     let frame_in_right_corner = Rect::from_xy(1919, 1050, 600, 600);
     assert!(is_in_corner(&frame_in_right_corner, &monitor));
 
-    let frame_in_left_corner = Rect::from_xy(1, 1050, 600, 600);
+    let frame_in_left_corner = Rect::from_xy(-599, 1050, 600, 600);
     assert!(is_in_corner(&frame_in_left_corner, &monitor));
   }
 


### PR DESCRIPTION
When I cloned the repo, there were several unit tests failing.  I always like to start refactoring work from a clean test run, so this fixes the tests that were broken.

1. wm: Corner detection test was wrong (not accounting for window width in the test data).
2. wm-platform: A platform-specific key was in the universal key mapping test.
3. wm-common: TilingDirection imports were broken in tests.
