### PR TITLE
test: mark non-compiling doc tests as ignore

### DIFF
--- a/packages/wm-macros/src/common/branch.rs
+++ b/packages/wm-macros/src/common/branch.rs
@@ -141,7 +141,7 @@ impl_for_tuple!(T, U, V, W, X, Y | 0, 1, 2, 3, 4, 5);
 /// Parse [syn::Ident] and [syn::LitStr] from the stream, which are
 /// separated by a comma. E.g. `some_name, "some string"`. If the order is
 /// reversed, it will fail to parse.
-/// ```
+/// ```ignore
 /// fn example(stream: syn::parse::ParseStream) -> syn::Result<()> {
 ///   type T = (syn::Ident, syn::LitStr);
 ///
@@ -220,7 +220,7 @@ where
 /// Parse [syn::Ident] and [syn::LitStr] from the stream in any order,
 /// which are separated by a comma. E.g. `some_name, "some string"` or
 /// `"some string", some_name`.
-/// ```
+/// ```ignore
 /// fn example(stream: proc_macro::TokenStream) -> syn::Result<(syn::Ident, syn::LitStr)> {
 ///   type T = (syn::Ident, syn::LitStr);
 ///
@@ -281,7 +281,7 @@ where
 ///
 /// # Example
 /// Parse [syn::Ident] if it is present, otherwise parse [syn::LitStr].
-/// ```
+/// ```ignore
 /// type IfElseType = IfElse<syn::Ident, syn::LitStr>;
 ///
 /// fn example(stream: syn::parse::ParseStream) -> syn::Result<IfElseType> {
@@ -347,7 +347,7 @@ where
 ///
 /// # Example
 /// Parse [syn::Ident] if it is present, otherwise return None.
-/// ```
+/// ```ignore
 /// type OptionalType = Optional<syn::Ident>;
 /// fn example(stream: syn::parse::ParseStream) -> syn::Result<OptionalType> {
 ///   stream.parse::<OptionalType>()
@@ -366,7 +366,7 @@ where
 /// ```
 /// Used in combination with [Ordered] to parse a [syn::Ident] and
 /// optionally a [syn::LitStr]:
-/// ```
+/// ```ignore
 /// type OrderedOptionalType = Ordered<(syn::Ident, Optional<syn::LitStr>),
 /// syn::Token![,]>;
 ///
@@ -388,7 +388,7 @@ where
 /// ```
 /// Used in combination with [Unordered] it can be used to parse a
 /// [syn::Ident] and optionally a [syn::LitStr] in any order:
-/// ```
+/// ```ignore
 /// type UnorderedOptionalType = Unordered<(syn::Ident, Optional<syn::LitStr>), syn::Token![,]>;
 ///
 /// fn example(stream: syn::parse::ParseStream) -> syn::Result<UnorderedOptionalType> {

--- a/packages/wm-macros/src/common/error_handling.rs
+++ b/packages/wm-macros/src/common/error_handling.rs
@@ -17,7 +17,7 @@ where
   /// `Ok(self)`.
   ///
   /// # Example
-  /// ```
+  /// ```ignore
   /// # fn example(string: &str, string_span: syn::Span) -> syn::Result<()> {
   /// string.is_empty().then_error(string_span.error("Expected a non-empty string"))?;
   /// # }
@@ -38,7 +38,7 @@ pub trait ToError {
   /// message.
   ///
   /// # Example
-  /// ```
+  /// ```ignore
   /// # fn example(ident: syn::Ident) -> syn::Result<()> {
   /// return Err(ident.error("Didn't expect an identifier here"));
   /// # }
@@ -69,7 +69,7 @@ pub trait ToSpanError {
   /// gives more accurately spanned errors.
   ///
   /// # Example
-  /// ```
+  /// ```ignore
   /// # fn example(stream: syn::parse::ParseStream) -> syn::Result<()> {
   /// return Err(stream.span().serror("Expected ..."));
   /// # }

--- a/packages/wm-macros/src/common/named_parameter.rs
+++ b/packages/wm-macros/src/common/named_parameter.rs
@@ -5,7 +5,7 @@
 ///
 /// # Example
 /// Parse a name-value pair of [syn::Ident] and [syn::LitStr].
-/// ```
+/// ```ignore
 /// type NamedParam = NamedParameter<syn::Ident, syn::LitStr>;
 ///
 /// fn example(stream: syn::parse::ParseStream) -> syn::Result<NamedParam> {

--- a/packages/wm-macros/src/common/parenthesized.rs
+++ b/packages/wm-macros/src/common/parenthesized.rs
@@ -5,7 +5,7 @@
 ///
 /// # Example
 /// Parse a [syn::Ident] within parenthesis:
-/// ```
+/// ```ignore
 /// type ParenthesizedIdent = wm_macros::Parenthesized<syn::Ident>;
 /// fn example(stream: syn::parse::ParseStream) -> syn::Result<ParenthesizedIdent> {
 ///   stream.parse::<ParenthesizedIdent>()

--- a/packages/wm-macros/src/common/peekable.rs
+++ b/packages/wm-macros/src/common/peekable.rs
@@ -71,7 +71,7 @@ pub trait Peekable {
   /// from the type (`Parse`).
   ///
   /// # Examble
-  /// ```
+  /// ```ignore
   /// fn peek_then_parse<T: Parse + Peekable>(stream: syn::parse::ParseStream) -> syn::Result<T> {
   ///   if stream.peek(T::peekable()) {
   ///     let value = stream.parse::<T>()?;
@@ -122,7 +122,7 @@ pub fn get_peek_display<T: syn::parse::Peek>(_peek: T) -> &'static str {
 /// rather than a value.
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// # fn example(stream: syn::parse::ParseStream) -> syn::Result<()> {
 /// // Allows for
 /// stream.tpeek::<syn::Ident>()?;

--- a/packages/wm-macros/src/lib.rs
+++ b/packages/wm-macros/src/lib.rs
@@ -37,7 +37,7 @@ mod prelude {
 /// ```
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// /// Your main enum documentation
 /// // Note that the defaults block does not apply to the main enum itself.
 /// #[derive(Clone, Debug, wm_macros::SubEnum)]
@@ -92,7 +92,7 @@ pub fn sub_enum(input: TokenStream) -> TokenStream {
 /// Creates `impl From<Inner> for Enum` and `impl TryFrom<Enum> for Inner`
 ///
 /// # Example
-/// ```
+/// ```ignore
 /// struct One;
 /// struct Two;
 ///

--- a/packages/wm-platform/src/display.rs
+++ b/packages/wm-platform/src/display.rs
@@ -223,7 +223,7 @@ pub trait DisplayDeviceExtWindows {
   ///
   /// # Example usage
   ///
-  /// ```rust,no_run
+  /// ```ignore
   /// device.device_path(); // "\\?\DISPLAY#DEL40A3#5&1234abcd&0&UID256#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}"
   /// device.hardware_id(); // Some("DEL40A3")
   /// ```


### PR DESCRIPTION
There are several doc examples that do not compile, mostly due to referencing internal types.  Marking them as "ignore" makes "cargo test --doc --all" happy.

This closes #1355 
