### PR TITLE
fix: allow moving workspaces to monitors that don't already have one

### DIFF
--- a/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
+++ b/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
@@ -23,8 +23,7 @@ pub fn move_workspace_in_direction(
 
   if let Some(target_monitor) = target_monitor {
     // Get currently displayed workspace on the target monitor.
-    let displayed_workspace = target_monitor
-      .displayed_workspace();
+    let displayed_workspace = target_monitor.displayed_workspace();
 
     move_container_within_tree(
       &workspace.clone().into(),
@@ -58,7 +57,7 @@ pub fn move_workspace_in_direction(
         .pending_sync
         .queue_cursor_jump()
         .queue_container_to_redraw(workspace.clone());
-        tracing::info!("Moving workspace to monitor that did not already have a workspace.");
+      tracing::info!("Moving workspace to monitor that did not already have a workspace.");
     }
 
     match origin_monitor.child_count() {

--- a/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
+++ b/packages/wm/src/commands/workspace/move_workspace_in_direction.rs
@@ -24,8 +24,7 @@ pub fn move_workspace_in_direction(
   if let Some(target_monitor) = target_monitor {
     // Get currently displayed workspace on the target monitor.
     let displayed_workspace = target_monitor
-      .displayed_workspace()
-      .context("No displayed workspace.")?;
+      .displayed_workspace();
 
     move_container_within_tree(
       &workspace.clone().into(),
@@ -48,11 +47,19 @@ pub fn move_workspace_in_direction(
       );
     }
 
-    state
-      .pending_sync
-      .queue_cursor_jump()
-      .queue_container_to_redraw(workspace.clone())
-      .queue_container_to_redraw(displayed_workspace);
+    if let Some(displayed_workspace) = displayed_workspace {
+      state
+        .pending_sync
+        .queue_cursor_jump()
+        .queue_container_to_redraw(workspace.clone())
+        .queue_container_to_redraw(displayed_workspace);
+    } else {
+      state
+        .pending_sync
+        .queue_cursor_jump()
+        .queue_container_to_redraw(workspace.clone());
+        tracing::info!("Moving workspace to monitor that did not already have a workspace.");
+    }
 
     match origin_monitor.child_count() {
       0 => {


### PR DESCRIPTION
Sometimes glazewm is in a state where there are no workspaces assigned to a monitor. A logical course of action in this state (in my opinion) is to send a command to move a workspace to that monitor. Currently, if you try that, glazewm displays an error (dialog box with text "No displayed workspace.") because it does not have a workspace to pass to `queue_container_to_redraw()`.
This PR adds a conditional so that if there is no pre-displayed workspace, we don't bother queueing a redraw for it. Moving a workspace to the monitor will now work instead of producing an error.
I have built and tested this code.

Worth noting that while https://github.com/glzr-io/glazewm/pull/1284/ should fix the main reason for glazewm ending up in a state where there are no workspaces assigned to a monitor, there are probably other ways to end up in the same situation, in which case this PR is still relevant to allowing people to remedy that situation.