### PR TITLE
test: add mocks for `wm-platform` structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ out/
 # IDE files
 .vs/
 .idea/
+
+# vi files
+.*.swp
+.*.swo

--- a/packages/wm-platform/Cargo.toml
+++ b/packages/wm-platform/Cargo.toml
@@ -20,6 +20,9 @@ tracing = { workspace = true }
 serde = { workspace = true }
 regex = { workspace = true }
 
+[features]
+test_utils = []
+
 [dev-dependencies]
 libtest-mimic-collect = "0.3.2"
 

--- a/packages/wm-platform/src/lib.rs
+++ b/packages/wm-platform/src/lib.rs
@@ -17,6 +17,9 @@ mod single_instance;
 mod thread_bound;
 mod window_listener;
 
+#[cfg(feature = "test_utils")]
+pub mod test_utils;
+
 pub use dispatcher::*;
 pub use display::*;
 pub use display_listener::*;

--- a/packages/wm-platform/src/test_utils.rs
+++ b/packages/wm-platform/src/test_utils.rs
@@ -1,0 +1,58 @@
+//! Utilities for testing.
+//!
+//! Available via the `test_utils` Cargo feature.
+use std::sync::{atomic::AtomicBool, Arc};
+
+use crate::platform_impl;
+#[cfg(target_os = "macos")]
+pub use crate::WindowId;
+pub use crate::{Dispatcher, Display, NativeWindow};
+
+impl Dispatcher {
+  /// Creates a mock `Dispatcher` for use in tests.
+  ///
+  /// Calling any methods on the mock is undefined behavior and may panic.
+  #[must_use]
+  pub fn mock() -> Self {
+    Self::new(None, Arc::new(AtomicBool::new(false)))
+  }
+}
+
+impl NativeWindow {
+  /// Creates a mock `NativeWindow` for use in tests.
+  ///
+  /// Calling any methods on the mock is undefined behavior and may panic.
+  #[must_use]
+  pub fn mock() -> Self {
+    #[cfg(target_os = "windows")]
+    {
+      platform_impl::NativeWindow::new(0).into()
+    }
+    #[cfg(target_os = "macos")]
+    {
+      #[allow(invalid_value)]
+      platform_impl::NativeWindow::new(
+        WindowId(0),
+        unsafe { std::mem::zeroed() },
+        unsafe { std::mem::zeroed() },
+      )
+      .into()
+    }
+  }
+}
+
+impl Display {
+  /// Creates a mock `Display` for use in tests.
+  ///
+  /// Calling any methods on the mock is undefined behavior and may panic.
+  #[must_use]
+  pub fn mock() -> Self {
+    Self {
+      #[cfg(target_os = "windows")]
+      inner: platform_impl::Display::new(0),
+      #[cfg(target_os = "macos")]
+      #[allow(invalid_value)]
+      inner: unsafe { std::mem::zeroed() },
+    }
+  }
+}


### PR DESCRIPTION
Tiny PR for non-functional mocks of platform types, to be used in future tests.