### PR TITLE
test: adding bon-based mocks for model types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "built"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +485,40 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.103",
 ]
@@ -1061,6 +1120,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "image"
@@ -1797,6 +1862,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3212,6 +3287,7 @@ dependencies = [
  "ambassador",
  "anyhow",
  "auto-launch",
+ "bon",
  "clap",
  "enum-as-inner",
  "futures-util",

--- a/packages/wm/Cargo.toml
+++ b/packages/wm/Cargo.toml
@@ -42,3 +42,7 @@ wm-common = { path = "../wm-common" }
 wm-ipc-client = { path = "../wm-ipc-client" }
 wm-macros = { workspace = true }
 wm-platform = { path = "../wm-platform" }
+
+[dev-dependencies]
+bon = "3"
+wm-platform = { path = "../wm-platform", features = ["test_utils"] }

--- a/packages/wm/src/commands/general/shell_exec.rs
+++ b/packages/wm/src/commands/general/shell_exec.rs
@@ -78,7 +78,7 @@ pub fn shell_exec(
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
 /// let (prog, args) = parse_command("code .")?;
 /// assert_eq!(prog, "code");
 /// assert_eq!(args, ".");

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -45,6 +45,9 @@ mod user_config;
 mod wm;
 mod wm_state;
 
+#[cfg(test)]
+mod test_utils;
+
 /// Main entry point for the application.
 ///
 /// Conditionally starts the WM or runs a CLI command based on the given

--- a/packages/wm/src/models/container.rs
+++ b/packages/wm/src/models/container.rs
@@ -36,6 +36,9 @@ use crate::{
 /// # Example
 /// Conversion between the different container types:
 /// ```
+/// use wm::models::{Container, DirectionContainer, SplitContainer, TilingContainer};
+/// use wm::traits::{TilingSizeGetters, TilingDirectionGetters};
+///
 /// fn example(split: SplitContainer) {
 ///   // Convert a `SplitContainer` into a `Container`
 ///   let container: Container = split.into(); // Will be a `Container::Split`

--- a/packages/wm/src/test_utils.rs
+++ b/packages/wm/src/test_utils.rs
@@ -1,0 +1,260 @@
+//! Test utilities for creating mock container instances.
+//!
+//! This module provides default values and helper functions used by the
+//! mock builders in the model modules.
+
+use bon::bon;
+use wm_common::{
+  FloatingStateConfig, GapsConfig, TilingDirection, WindowState,
+  WorkspaceConfig,
+};
+use wm_platform::{Display, NativeWindow, Rect, RectDelta};
+
+use crate::{
+  commands::container::attach_container,
+  models::{
+    Monitor, NativeMonitorProperties, NativeWindowProperties,
+    NonTilingWindow, SplitContainer, TilingContainer, TilingWindow,
+    Workspace,
+  },
+  traits::TilingSizeGetters,
+};
+
+pub const MOCK_MONITOR_WIDTH: i32 = 1680;
+pub const MOCK_MONITOR_HEIGHT: i32 = 1050;
+pub const MOCK_TASKBAR_HEIGHT: i32 = 50;
+pub const MOCK_DPI: u32 = 96;
+pub const MOCK_SCALE_FACTOR: f32 = 1.0;
+pub const MOCK_WINDOW_WIDTH: i32 = 300;
+pub const MOCK_WINDOW_HEIGHT: i32 = 200;
+
+pub fn mock_bounds() -> Rect {
+  Rect::from_xy(0, 0, MOCK_MONITOR_WIDTH, MOCK_MONITOR_HEIGHT)
+}
+
+pub fn mock_working_area() -> Rect {
+  Rect::from_xy(
+    0,
+    0,
+    MOCK_MONITOR_WIDTH,
+    MOCK_MONITOR_HEIGHT - MOCK_TASKBAR_HEIGHT,
+  )
+}
+
+pub fn mock_window_rect() -> Rect {
+  Rect::from_xy(0, 0, MOCK_WINDOW_WIDTH, MOCK_WINDOW_HEIGHT)
+}
+
+pub fn mock_border_delta() -> RectDelta {
+  RectDelta::zero()
+}
+
+#[bon]
+impl Monitor {
+  #[builder]
+  pub fn mock(
+    #[builder(default = String::new())] device_name: String,
+    #[builder(default = mock_bounds())] bounds: Rect,
+    #[builder(default = mock_working_area())] working_area: Rect,
+    #[builder(default = MOCK_DPI)] dpi: u32,
+    #[builder(default = MOCK_SCALE_FACTOR)] scale_factor: f32,
+    #[builder(default = Display::mock())] native: Display,
+    #[builder(default = vec![])] workspaces: Vec<Workspace>,
+  ) -> Self {
+    let properties = NativeMonitorProperties::mock()
+      .device_name(device_name)
+      .bounds(bounds)
+      .working_area(working_area)
+      .dpi(dpi)
+      .scale_factor(scale_factor)
+      .call();
+
+    let monitor = Self::new(native, properties);
+
+    for workspace in workspaces {
+      attach_container(&workspace.into(), &monitor.clone().into(), None)
+        .unwrap();
+    }
+
+    monitor
+  }
+}
+
+#[bon]
+impl NativeMonitorProperties {
+  #[builder]
+  pub fn mock(
+    #[builder(default = String::new())] device_name: String,
+    #[builder(default = mock_bounds())] bounds: Rect,
+    #[builder(default = mock_working_area())] working_area: Rect,
+    #[builder(default = MOCK_DPI)] dpi: u32,
+    #[builder(default = MOCK_SCALE_FACTOR)] scale_factor: f32,
+  ) -> Self {
+    Self {
+      device_name,
+      bounds,
+      working_area,
+      dpi,
+      scale_factor,
+      #[cfg(target_os = "macos")]
+      device_uuid: String::new(),
+      #[cfg(target_os = "windows")]
+      handle: 0,
+      #[cfg(target_os = "windows")]
+      hardware_id: None,
+      #[cfg(target_os = "windows")]
+      device_path: None,
+    }
+  }
+}
+
+#[bon]
+impl NativeWindowProperties {
+  #[builder]
+  pub fn mock(
+    #[builder(default = String::new())] title: String,
+    #[builder(default = String::new())] process_name: String,
+    #[builder(default = mock_window_rect())] frame: Rect,
+    #[builder(default = false)] is_minimized: bool,
+    #[builder(default = false)] is_maximized: bool,
+    #[builder(default = true)] is_resizable: bool,
+  ) -> Self {
+    Self {
+      title,
+      process_name,
+      frame,
+      is_minimized,
+      is_maximized,
+      is_resizable,
+      #[cfg(target_os = "windows")]
+      class_name: String::new(),
+      #[cfg(target_os = "windows")]
+      shadow_borders: mock_border_delta(),
+    }
+  }
+}
+
+#[bon]
+impl NonTilingWindow {
+  #[builder]
+  pub fn mock(
+    #[builder(default = String::new())] title: String,
+    #[builder(default = String::new())] process_name: String,
+    #[builder(default = mock_window_rect())] floating_placement: Rect,
+    #[builder(default = WindowState::Floating(FloatingStateConfig::default()))]
+    state: WindowState,
+    #[builder(default = NativeWindow::mock())] native: NativeWindow,
+  ) -> Self {
+    let properties = NativeWindowProperties::mock()
+      .title(title)
+      .process_name(process_name)
+      .frame(floating_placement.clone())
+      .call();
+
+    Self::new(
+      None,
+      native,
+      properties,
+      state,
+      None,
+      mock_border_delta(),
+      None,
+      floating_placement,
+      false,
+      vec![],
+      None,
+    )
+  }
+}
+
+#[bon]
+impl SplitContainer {
+  #[builder]
+  #[allow(clippy::cast_precision_loss)]
+  pub fn mock(
+    #[builder(default = TilingDirection::Horizontal)]
+    tiling_direction: TilingDirection,
+    #[builder(default = GapsConfig::default())] gaps_config: GapsConfig,
+    #[builder(default = vec![])] tiling_containers: Vec<TilingContainer>,
+  ) -> Self {
+    let split = Self::new(tiling_direction, gaps_config);
+
+    for child in tiling_containers {
+      attach_container(&child.into(), &split.clone().into(), None)
+        .unwrap();
+    }
+
+    split
+  }
+}
+
+#[bon]
+impl TilingWindow {
+  #[builder]
+  pub fn mock(
+    #[builder(default = 1.0)] tiling_size: f32,
+    #[builder(default = String::new())] title: String,
+    #[builder(default = String::new())] process_name: String,
+    #[builder(default = mock_window_rect())] floating_placement: Rect,
+    #[builder(default = GapsConfig::default())] gaps_config: GapsConfig,
+    #[builder(default = NativeWindow::mock())] native: NativeWindow,
+  ) -> Self {
+    let properties = NativeWindowProperties::mock()
+      .title(title)
+      .process_name(process_name)
+      .frame(floating_placement.clone())
+      .call();
+
+    let window = Self::new(
+      None,
+      native,
+      properties,
+      None,
+      mock_border_delta(),
+      floating_placement,
+      false,
+      gaps_config,
+      vec![],
+      None,
+    );
+
+    window.set_tiling_size(tiling_size);
+
+    window
+  }
+}
+
+#[bon]
+impl Workspace {
+  #[builder]
+  pub fn mock(
+    #[builder(default = "1".to_string())] name: String,
+    display_name: Option<String>,
+    #[builder(default = TilingDirection::Horizontal)]
+    tiling_direction: TilingDirection,
+    #[builder(default = GapsConfig::default())] gaps_config: GapsConfig,
+    #[builder(default = vec![])] tiling_containers: Vec<TilingContainer>,
+    #[builder(default = vec![])] non_tiling_windows: Vec<NonTilingWindow>,
+  ) -> Self {
+    let config = WorkspaceConfig {
+      name,
+      display_name,
+      bind_to_monitor: None,
+      keep_alive: false,
+    };
+
+    let workspace = Self::new(config, gaps_config, tiling_direction);
+
+    for child in tiling_containers {
+      attach_container(&child.into(), &workspace.clone().into(), None)
+        .unwrap();
+    }
+
+    for child in non_tiling_windows {
+      attach_container(&child.into(), &workspace.clone().into(), None)
+        .unwrap();
+    }
+
+    workspace
+  }
+}


### PR DESCRIPTION
This adds bon-based mocks for the model types (containers and their properties).  It also fixes a few doc test failures and clippy artifacts.