### PR TITLE
feat: Add option to disable device change from triggering handle_display_settings_changed

### DIFF
--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -96,6 +96,12 @@ pub struct GeneralConfig {
 
   /// Affects which windows get shown in the native Windows taskbar.
   pub show_all_in_taskbar: bool,
+
+  /// Whether to re-evaluate display settings when a non-display device
+  /// change is detected (e.g. a USB peripheral or audio device). Disable
+  /// this if plugging in USB devices causes unwanted window re-layout.
+  /// ** Exclusive to Windows due to `WM_DEVICECHANGE` API.
+  pub listen_for_device_changes: bool,
 }
 
 impl Default for GeneralConfig {
@@ -118,6 +124,7 @@ impl Default for GeneralConfig {
         }
       },
       show_all_in_taskbar: false,
+      listen_for_device_changes: true,
     }
   }
 }

--- a/packages/wm-platform/src/display_listener.rs
+++ b/packages/wm-platform/src/display_listener.rs
@@ -2,12 +2,26 @@ use tokio::sync::mpsc;
 
 use crate::{platform_impl, Dispatcher};
 
+/// The kind of change that triggered a display settings event.
+#[derive(Clone, Debug)]
+pub enum DisplayEventKind {
+  /// A display was connected/disconnected, or its resolution or arrangement
+  /// changed (`WM_DISPLAYCHANGE` on Windows).
+  DisplayChanged,
+  /// The working area changed, e.g. due to a taskbar resize or appbar
+  /// registration (`WM_SETTINGCHANGE` with `SPI_SETWORKAREA` on Windows).
+  WorkAreaChanged,
+  /// A non-display device node changed (`WM_DEVICECHANGE` on Windows).
+  /// This fires for any device, including USB peripherals and audio devices.
+  DeviceChanged,
+}
+
 /// A listener for system-wide display setting changes.
 ///
 /// Detects changes to display configuration including resolution changes,
 /// display connections/disconnections, and working area changes.
 pub struct DisplayListener {
-  event_rx: mpsc::UnboundedReceiver<()>,
+  event_rx: mpsc::UnboundedReceiver<DisplayEventKind>,
 
   /// Inner platform-specific display listener.
   inner: platform_impl::DisplayListener,
@@ -24,7 +38,7 @@ impl DisplayListener {
   /// Returns when the next display settings change is detected.
   ///
   /// Returns `None` if the channel has been closed.
-  pub async fn next_event(&mut self) -> Option<()> {
+  pub async fn next_event(&mut self) -> Option<DisplayEventKind> {
     self.event_rx.recv().await
   }
 

--- a/packages/wm-platform/src/platform_impl/macos/display_listener.rs
+++ b/packages/wm-platform/src/platform_impl/macos/display_listener.rs
@@ -8,7 +8,7 @@ use crate::{
     NotificationCenter, NotificationEvent, NotificationName,
     NotificationObserver,
   },
-  Dispatcher, ThreadBound,
+  Dispatcher, DisplayEventKind, ThreadBound,
 };
 
 /// Platform-specific implementation of [`DisplayListener`].
@@ -20,7 +20,7 @@ pub(crate) struct DisplayListener {
 impl DisplayListener {
   /// Creates an instance of `DisplayListener`.
   pub(crate) fn new(
-    event_tx: mpsc::UnboundedSender<()>,
+    event_tx: mpsc::UnboundedSender<DisplayEventKind>,
     dispatcher: &Dispatcher,
   ) -> crate::Result<Self> {
     let dispatcher_clone = dispatcher.clone();
@@ -48,7 +48,7 @@ impl DisplayListener {
 
   /// Registers notification observers on the main thread.
   fn add_observers(
-    event_tx: mpsc::UnboundedSender<()>,
+    event_tx: mpsc::UnboundedSender<DisplayEventKind>,
     dispatcher: Dispatcher,
   ) -> ThreadBound<Retained<NotificationObserver>> {
     let (observer, mut events_rx) = NotificationObserver::new();
@@ -104,7 +104,7 @@ impl DisplayListener {
             std::thread::spawn(move || {
               std::thread::sleep(WAKE_COALESCE_DURATION);
 
-              if let Err(err) = event_tx.send(()) {
+              if let Err(err) = event_tx.send(DisplayEventKind::DisplayChanged) {
                 tracing::warn!(
                   "Failed to send display change event: {}",
                   err
@@ -127,7 +127,7 @@ impl DisplayListener {
               wake_time = None;
             }
 
-            if let Err(err) = event_tx.send(()) {
+            if let Err(err) = event_tx.send(DisplayEventKind::DisplayChanged) {
               tracing::warn!(
                 "Failed to send display change event: {}",
                 err

--- a/packages/wm-platform/src/platform_impl/windows/display_listener.rs
+++ b/packages/wm-platform/src/platform_impl/windows/display_listener.rs
@@ -11,7 +11,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
   WM_POWERBROADCAST, WM_SETTINGCHANGE,
 };
 
-use crate::{Dispatcher, DispatcherExtWindows};
+use crate::{Dispatcher, DispatcherExtWindows, DisplayEventKind};
 
 /// Platform-specific implementation of [`DisplayListener`].
 pub(crate) struct DisplayListener {
@@ -22,7 +22,7 @@ pub(crate) struct DisplayListener {
 impl DisplayListener {
   /// Implements [`DisplayListener::new`].
   pub(crate) fn new(
-    event_tx: mpsc::UnboundedSender<()>,
+    event_tx: mpsc::UnboundedSender<DisplayEventKind>,
     dispatcher: &Dispatcher,
   ) -> crate::Result<Self> {
     let is_system_suspended = Arc::new(AtomicBool::new(false));
@@ -47,35 +47,33 @@ impl DisplayListener {
             Some(0)
           }
           WM_DISPLAYCHANGE | WM_SETTINGCHANGE | WM_DEVICECHANGE => {
-            let should_emit = {
-              // Ignore display change messages if the system hasn't fully
-              // resumed from sleep.
-              if is_system_suspended.load(Ordering::Relaxed) {
-                false
-              } else {
-                #[allow(clippy::cast_possible_truncation)]
-                match message {
-                  // Received when displays are connected and disconnected,
-                  // resolution changes, or arrangement changes.
-                  WM_DISPLAYCHANGE => true,
-                  // Received when the working area has changed. Fires when
-                  // the Windows taskbar is changed or an appbar is
-                  // registered or changed. 3rd-party apps like
-                  // ButteryTaskbar can trigger this message by calling
-                  // `SystemParametersInfo(SPI_SETWORKAREA, ...)`.
-                  WM_SETTINGCHANGE => wparam as u32 == SPI_SETWORKAREA.0,
-                  // Received when any device is connected or disconnected
-                  // (including non-display devices).
-                  // TODO: Check if this is actually needed. Previous C#
-                  // implementation did not use this.
-                  WM_DEVICECHANGE => wparam as u32 == DBT_DEVNODES_CHANGED,
-                  _ => unreachable!(),
-                }
-              }
-            };
+            // Ignore display change messages if the system hasn't fully
+            // resumed from sleep.
+            if !is_system_suspended.load(Ordering::Relaxed) {
+              #[allow(clippy::cast_possible_truncation)]
+              let event_kind = match message {
+                // Received when displays are connected and disconnected,
+                // resolution changes, or arrangement changes.
+                WM_DISPLAYCHANGE => Some(DisplayEventKind::DisplayChanged),
+                // Received when the working area has changed. Fires when
+                // the Windows taskbar is changed or an appbar is
+                // registered or changed. 3rd-party apps like
+                // ButteryTaskbar can trigger this message by calling
+                // `SystemParametersInfo(SPI_SETWORKAREA, ...)`.
+                WM_SETTINGCHANGE => (wparam as u32 == SPI_SETWORKAREA.0)
+                  .then_some(DisplayEventKind::WorkAreaChanged),
+                // Received when any device is connected or disconnected
+                // (including non-display devices).
+                // TODO: Check if this is actually needed. Previous C#
+                // implementation did not use this.
+                WM_DEVICECHANGE => (wparam as u32 == DBT_DEVNODES_CHANGED)
+                  .then_some(DisplayEventKind::DeviceChanged),
+                _ => unreachable!(),
+              };
 
-            if should_emit {
-              let _ = event_tx.send(());
+              if let Some(kind) = event_kind {
+                let _ = event_tx.send(kind);
+              }
             }
 
             Some(0)

--- a/packages/wm/src/main.rs
+++ b/packages/wm/src/main.rs
@@ -206,9 +206,15 @@ async fn start_wm(
         tracing::debug!("Received window event: {:?}", event);
         wm.process_event(PlatformEvent::Window(event), &mut config)
       },
-      Some(()) = display_listener.next_event() => {
-        tracing::debug!("Received display settings changed event.");
-        wm.process_event(PlatformEvent::DisplaySettingsChanged, &mut config)
+      Some(event_kind) = display_listener.next_event() => {
+        tracing::debug!("Received display event: {:?}.", event_kind);
+        if matches!(event_kind, wm_platform::DisplayEventKind::DeviceChanged)
+          && !config.value.general.listen_for_device_changes
+        {
+          Ok(())
+        } else {
+          wm.process_event(PlatformEvent::DisplaySettingsChanged, &mut config)
+        }
       },
       Some(event) = keybinding_listener.next_event() => {
         tracing::debug!("Received keyboard event: {:?}", event);


### PR DESCRIPTION
## Problem

`WM_DEVICECHANGE` currently triggers the full `handle_display_settings_changed` logic when USB devices are plugged and unplugged. This causes GlazeWM to perform a lot of unnecessary logic to handle the new "display", when there hasn't actually been a display change.  In particular, this causes a freeze up when used with a KVM that has EDID emulation and doesn't actually need a display re-render.

There is already a TODO comment in `display_listener.rs` noting this may not be necessary, as the previous C# implementation did not handle `WM_DEVICECHANGE` at all.  With this change, we can safely disable it through a config option and check for stability long term before deciding if we should fully remove this event handler.

  ## Changes

  - Introduces `DisplayEventKind` enum (`DisplayChanged`, `WorkAreaChanged`, `DeviceChanged`) so callers can distinguish the source of a display event
  - Adds a `general.listen_for_device_changes` config option (default `true` for backwards compatibility) that allows opting out of `WM_DEVICECHANGE` handling

  ## Usage

  ```yaml
  general:
    listen_for_device_changes: false

  keybindings:
    - commands: ['wm-sync-displays']
      bindings: ['...']