### PR TITLE
docs: document single_window_outer_gap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,14 @@ gaps:
     right: "20px"
     bottom: "20px"
     left: "20px"
+
+  # Gap if there is only a single window.
+  single_window_outer_gap:
+    top: '20px'
+    right: '20px'
+    bottom: '20px'
+    left: '20px'
+
 ```
 
 ### Config: Workspaces


### PR DESCRIPTION
The single_window_outer_gap config option introduced in https://github.com/glzr-io/glazewm/pull/933 was not documented in the README until now.

We could also think about defaulting this to `0px` or something else than the default "non"-single window gap options, since the intention behind the `single_window_outer_gap` is to have a different behavior in case of a _single_ window (i.e. smart gaps like in i3/sway).