### PR TITLE
feat: add `workspace.toggle_on_refocus` workspace config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ workspaces:
 
     # Optionally prevent workspace from being deactivated when empty.
     keep_alive: false
+
+    # Optionally toggle between this workspace, and the most recent workspace when focusing this workspace
+    # Like the `toggle_workspace_on_refocus` global option, but specific to this workspace
+    # If this option is specified as `false` and the `toggle_workspace_on_refocus` option is set to `true` then this workspace will not toggle
+    toggle_on_refocus: false
 ```
 
 ### Config: Window rules

--- a/packages/wm-common/src/app_command.rs
+++ b/packages/wm-common/src/app_command.rs
@@ -431,4 +431,7 @@ pub struct InvokeUpdateWorkspaceConfig {
 
   #[clap(long)]
   pub keep_alive: Option<bool>,
+
+  #[clap(long)]
+  pub toggle_on_refocus: Option<bool>,
 }

--- a/packages/wm-common/src/parsed_config.rs
+++ b/packages/wm-common/src/parsed_config.rs
@@ -385,6 +385,9 @@ pub struct WorkspaceConfig {
 
   #[serde(default = "default_bool::<false>")]
   pub keep_alive: bool,
+
+  #[serde(default)]
+  pub toggle_on_refocus: Option<bool>,
 }
 
 /// Helper function for setting a default value for a boolean field.

--- a/packages/wm/src/commands/workspace/update_workspace_config.rs
+++ b/packages/wm/src/commands/workspace/update_workspace_config.rs
@@ -38,6 +38,9 @@ pub fn update_workspace_config(
       .bind_to_monitor
       .or(current_config.bind_to_monitor),
     keep_alive: new_config.keep_alive.unwrap_or(current_config.keep_alive),
+    toggle_on_refocus: new_config
+      .toggle_on_refocus
+      .or(current_config.toggle_on_refocus),
   };
 
   workspace.set_config(updated_config);

--- a/packages/wm/src/test_utils.rs
+++ b/packages/wm/src/test_utils.rs
@@ -241,6 +241,7 @@ impl Workspace {
       display_name,
       bind_to_monitor: None,
       keep_alive: false,
+      toggle_on_refocus: None,
     };
 
     let workspace = Self::new(config, gaps_config, tiling_direction);

--- a/packages/wm/src/wm_state.rs
+++ b/packages/wm/src/wm_state.rs
@@ -361,17 +361,24 @@ impl WmState {
   ) -> anyhow::Result<(Option<String>, Option<Workspace>)> {
     let (name, workspace) = match target {
       WorkspaceTarget::Name(name) => {
+        let ws_toggle = origin_workspace.config().toggle_on_refocus;
         #[allow(clippy::match_bool)]
         match origin_workspace.config().name == name {
           false => (Some(name.clone()), self.workspace_by_name(&name)),
           // Toggle the workspace if it's already focused.
-          true if config.value.general.toggle_workspace_on_refocus => (
-            self.recent_workspace_name.clone(),
-            self
-              .recent_workspace_name
-              .as_ref()
-              .and_then(|name| self.workspace_by_name(name)),
-          ),
+          true
+            if (config.value.general.toggle_workspace_on_refocus
+              && ws_toggle != Some(false))
+              || ws_toggle == Some(true) =>
+          {
+            (
+              self.recent_workspace_name.clone(),
+              self
+                .recent_workspace_name
+                .as_ref()
+                .and_then(|name| self.workspace_by_name(name)),
+            )
+          }
           true => (None, None),
         }
       }


### PR DESCRIPTION
### Summary
This feature adds the config option under each workspace to be able to toggle back to the most recent workspace when refocusing the workspace. The option is labeled `toggle_on_refocus` to match the global option.

### Details
- The local `workspace.toggle_on_refocus` option overrides the `global.toggle_workspace_on_refocus` option for the individual workspace. If the global option is true, and the local option is not Some(false), or if the global option is false, but the workspace local option is Some(true) then the option is enabled. (logic for this at **packages/wm/src/wm_state.rs:369-381**)
- This option piggybacks on the functionality of the `global.toggle_workspace_on_refocus` option, but is configured at the workspace level.